### PR TITLE
chore: upgrade upload-artifact@v4 to @v7 across all CI jobs

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -79,7 +79,7 @@ jobs:
 
     - name: Upload test results
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: test-results-linux-${{ matrix.compiler }}
         path: build/Testing/
@@ -153,7 +153,7 @@ jobs:
 
     - name: Upload clang-tidy log
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: clang-tidy-log
         path: /tmp/clang-tidy.log
@@ -231,7 +231,7 @@ jobs:
 
     - name: Upload logs on failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: smoke-test-logs
         path: /tmp/quantclaw-smoke-ci/
@@ -270,7 +270,7 @@ jobs:
 
     - name: Upload logs on failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: onboard-test-logs
         path: /tmp/quantclaw-onboard-*/
@@ -309,7 +309,7 @@ jobs:
 
     - name: Upload logs on failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: cli-test-logs
         path: /tmp/quantclaw-cli-*/
@@ -400,7 +400,7 @@ jobs:
 
     - name: Upload results on failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: sanitizer-${{ matrix.sanitizer }}-results
         path: build/Testing/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependencies to latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->