### PR TITLE
fix(gateway): eliminate use-after-free in Send*/Broadcast via shared_ptr

### DIFF
--- a/include/quantclaw/gateway/gateway_server.hpp
+++ b/include/quantclaw/gateway/gateway_server.hpp
@@ -159,10 +159,12 @@ class GatewayServer : public quantclaw::Noncopyable {
 
   mutable std::mutex connections_mutex_;
   std::unordered_map<std::string, ClientConnection> connections_;
-  // Non-owning WebSocket pointers. Lifetime managed by ixwebsocket:
-  // valid from Open callback until Close callback. Always access under
-  // connections_mutex_ and verify key exists in connections_ first.
-  std::unordered_map<std::string, ix::WebSocket*> ws_connections_;
+  // Shared ownership of each WebSocket obtained from server_->getClients() at
+  // Open time. Shared_ptr keeps the object alive across the snapshot-then-send
+  // window in BroadcastEvent / SendEventTo / SendResponseTo, eliminating the
+  // potential use-after-free that existed with raw pointers.
+  std::unordered_map<std::string, std::shared_ptr<ix::WebSocket>>
+      ws_connections_;
 
   std::mutex handlers_mutex_;
   std::unordered_map<std::string, RpcHandler> handlers_;

--- a/src/gateway/gateway_server.cpp
+++ b/src/gateway/gateway_server.cpp
@@ -85,28 +85,29 @@ void GatewayServer::BroadcastEvent(const std::string& event,
   evt.payload = payload;
   std::string msg = evt.ToJson().dump();
 
-  // Snapshot WebSocket pointers under the mutex, then send outside it.
-  // Prevents lock-order inversion: connections_mutex_ -> ixwebsocket internal
-  // (from ws->send) vs ixwebsocket internal -> connections_mutex_ (from the
-  // on_connection callback invoked by the ixwebsocket server thread).
-  std::vector<ix::WebSocket*> targets;
+  // Snapshot shared_ptrs under the mutex, then send outside it.
+  // Sending while holding connections_mutex_ risks lock-order inversion
+  // (connections_mutex_ -> ixwebsocket send-lock vs ixwebsocket callback-lock
+  // -> connections_mutex_). Shared_ptr snapshots guarantee the WebSocket
+  // objects remain alive across the send window.
+  std::vector<std::shared_ptr<ix::WebSocket>> targets;
   {
     std::lock_guard<std::mutex> lock(connections_mutex_);
     targets.reserve(ws_connections_.size());
-    for (auto& [id, ws] : ws_connections_) {
-      if (ws && connections_.count(id)) {
-        targets.push_back(ws);
+    for (auto& [id, ws_ptr] : ws_connections_) {
+      if (ws_ptr && connections_.count(id)) {
+        targets.push_back(ws_ptr);
       }
     }
   }
-  for (auto* ws : targets) {
-    ws->send(msg);
+  for (auto& ws_ptr : targets) {
+    ws_ptr->send(msg);
   }
 }
 
 void GatewayServer::SendEventTo(const std::string& connection_id,
                                 const RpcEvent& event) {
-  ix::WebSocket* target = nullptr;
+  std::shared_ptr<ix::WebSocket> target;
   {
     std::lock_guard<std::mutex> lock(connections_mutex_);
     if (connections_.count(connection_id) == 0) {
@@ -138,7 +139,7 @@ void GatewayServer::SendResponseTo(const std::string& connection_id,
   }
 
   std::string payload_str = resp.ToJson().dump();
-  ix::WebSocket* target = nullptr;
+  std::shared_ptr<ix::WebSocket> target;
   {
     std::lock_guard<std::mutex> lock(connections_mutex_);
     if (connections_.count(connection_id) == 0)
@@ -226,6 +227,22 @@ void GatewayServer::on_connection(std::shared_ptr<ix::ConnectionState> state,
     case ix::WebSocketMessageType::Open: {
       logger_->info("Client connected: {}", conn_id);
 
+      // Retrieve the shared_ptr for this connection from ixwebsocket's client
+      // set. Must be done before acquiring connections_mutex_ to avoid a
+      // lock-order inversion with ixwebsocket's internal _clientsMutex
+      // (path: _clientsMutex -> connections_mutex_ in on_connection vs.
+      //  connections_mutex_ -> _clientsMutex in getClients).
+      std::shared_ptr<ix::WebSocket> ws_ptr;
+      for (auto& c : server_->getClients()) {
+        if (c.get() == &ws) {
+          ws_ptr = c;
+          break;
+        }
+      }
+      if (!ws_ptr) {
+        logger_->warn("Could not find shared_ptr for connection {}", conn_id);
+      }
+
       {
         std::lock_guard<std::mutex> lock(connections_mutex_);
         ClientConnection client;
@@ -235,7 +252,7 @@ void GatewayServer::on_connection(std::shared_ptr<ix::ConnectionState> state,
                 std::chrono::system_clock::now().time_since_epoch())
                 .count();
         connections_[conn_id] = client;
-        ws_connections_[conn_id] = &ws;
+        ws_connections_[conn_id] = ws_ptr;  // may be null; sends dropped safely
       }
 
       // Send challenge


### PR DESCRIPTION
## Problem

`BroadcastEvent`, `SendEventTo`, and `SendResponseTo` snapshot a raw `ix::WebSocket*` under `connections_mutex_`, release the lock, then call `send()` on the pointer. If ixwebsocket's GC thread runs `purgeExpiredClients()` between the snapshot and the `send()`, the pointer is dangling — a potential use-after-free.

The existing design purposely releases the lock before sending to avoid a lock-order inversion:
- Path A: `connections_mutex_` → ixwebsocket send-lock (via `ws->send()`)
- Path B: ixwebsocket callback-lock → `connections_mutex_` (via `on_connection`)

## Fix

Change `ws_connections_` from `unordered_map<string, ix::WebSocket*>` to `unordered_map<string, shared_ptr<ix::WebSocket>>`.

At `Open` time, `server_->getClients()` is called **before** acquiring `connections_mutex_` (preserving lock-order invariants with ixwebsocket's internal `_clientsMutex`). The resulting `shared_ptr` is stored in `ws_connections_`. The three send methods snapshot this `shared_ptr` under the lock, then `send()` after release — the `shared_ptr` keeps the WebSocket object alive across the entire window.

## Test plan

- [ ] All existing gateway/e2e/rpc tests pass (CI)
- [ ] TSan build passes (no new races introduced)
- [ ] Linux gcc, clang, Windows MSVC builds pass

Closes #51