### PR TITLE
fix(review): address PR #56 Copilot/CodeRabbit review comments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,8 @@ if(NOT httplib_FOUND)
     find_package(ZLIB QUIET)
     if(ZLIB_FOUND)
         set(HTTPLIB_REQUIRE_ZLIB ON CACHE BOOL "" FORCE)
+    else()
+        set(HTTPLIB_REQUIRE_ZLIB OFF CACHE BOOL "" FORCE)
     endif()
     FetchContent_Declare(
         httplib

--- a/include/quantclaw/cli/agent_commands.hpp
+++ b/include/quantclaw/cli/agent_commands.hpp
@@ -27,7 +27,9 @@ class AgentCommands {
     auth_token_ = token;
   }
   void SetDefaultTimeoutMs(int ms) {
-    default_timeout_ms_ = ms;
+    if (ms > 0) {
+      default_timeout_ms_ = ms;
+    }
   }
 
  private:

--- a/src/cli/session_commands.cpp
+++ b/src/cli/session_commands.cpp
@@ -136,7 +136,7 @@ int SessionCommands::HistoryCommand(const std::vector<std::string>& args) {
             content = c.get<std::string>();
           } else if (c.is_array()) {
             for (const auto& block : c) {
-              if (block.value("type", "") == "text") {
+              if (block.is_object() && block.value("type", "") == "text") {
                 if (!content.empty()) {
                   content += "\n";
                 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1354,11 +1354,25 @@ int main(int argc, char* argv[]) {
          }
          return 0;
 #else
+         // Single-quote the path so spaces and shell metacharacters
+         // in the log file path don't break or inject into the command.
+         auto shell_quote = [](const std::string& s) {
+           std::string out = "'";
+           for (char ch : s) {
+             if (ch == '\'') {
+               out += "'\"'\"'";
+             } else {
+               out += ch;
+             }
+           }
+           out += "'";
+           return out;
+         };
          std::string cmd =
              follow
                  ? "tail -f "
                  : "tail -n " + std::to_string(lines) + " ";
-         cmd += log_file.string();
+         cmd += shell_quote(log_file.string());
          return std::system(cmd.c_str());
 #endif
        }});

--- a/tests/test-cli.sh
+++ b/tests/test-cli.sh
@@ -321,13 +321,16 @@ else
     fail "C5.4 dashboard (prints URL)" "output: $OUT"
 fi
 
-# C5.5 logs — when no log file exists, should report clearly (not crash)
-OUT=$(timeout 3 bash -c "HOME='$TEST_HOME' '$BINARY' logs" 2>&1 || true)
-if echo "$OUT" | grep -qi "no log file\|log\|journal\|gateway"; then
+# C5.5 logs — when no log file exists, should exit within 3s (not hang) and
+# produce recognisable output; exit code 124 means the command hung (fail).
+LOGS_EC=0
+OUT=$(timeout 3 bash -c "HOME='$TEST_HOME' '$BINARY' logs" 2>&1) || LOGS_EC=$?
+if [ "$LOGS_EC" -eq 124 ]; then
+    fail "C5.5 logs (hung — timed out after 3s)" ""
+elif echo "$OUT" | grep -qi "no log file\|log\|journal\|gateway\|cannot open\|error"; then
     pass "C5.5 logs (graceful when no log file)"
 else
-    # On some setups logs may succeed; that's also fine
-    pass "C5.5 logs (no crash)"
+    pass "C5.5 logs (completed, exit $LOGS_EC)"
 fi
 
 # ==========================================================
@@ -448,8 +451,11 @@ qc sessions reset "$SESSION_KEY" >/dev/null 2>&1
 pass "C7.3 sessions reset (no crash)"
 
 # C7.4 sessions delete (nonexistent key — idempotent, should not crash)
-qc sessions delete "nonexistent:$$:key" >/dev/null 2>&1
-pass "C7.4 sessions delete nonexistent (no crash)"
+if qc sessions delete "nonexistent:$$:key" >/dev/null 2>&1; then
+    pass "C7.4 sessions delete nonexistent (no crash)"
+else
+    fail "C7.4 sessions delete nonexistent (no crash)" "exit code: $?"
+fi
 
 # C7.5 gateway call — sessions.list
 OUT=$(qc gateway call sessions.list 2>&1)

--- a/tests/test_api_routes.cpp
+++ b/tests/test_api_routes.cpp
@@ -97,7 +97,7 @@ class ApiRoutesTest : public ::testing::Test {
     gateway_server_ =
         std::make_unique<quantclaw::gateway::GatewayServer>(gw_port_, logger_);
     gateway_server_->SetAuth("none", "");
-    quantclaw::test::ReleaseHeldPorts();
+    quantclaw::test::ReleaseHeldPort(gw_port_);
     gateway_server_->Start();
 
     // HTTP API server
@@ -109,6 +109,7 @@ class ApiRoutesTest : public ::testing::Test {
         *http_server_, session_manager_, agent_loop_, prompt_builder_,
         tool_registry_, config_, *gateway_server_, logger_);
 
+    quantclaw::test::ReleaseHeldPort(http_port_);
     http_server_->Start();
     ASSERT_TRUE(quantclaw::test::WaitForServerReady(http_port_, 5000))
         << "HTTP server not ready on port " << http_port_;
@@ -376,7 +377,7 @@ class ApiRoutesAuthTest : public ::testing::Test {
     gateway_server_ =
         std::make_unique<quantclaw::gateway::GatewayServer>(gw_port_, logger_);
     gateway_server_->SetAuth("none", "");
-    quantclaw::test::ReleaseHeldPorts();
+    quantclaw::test::ReleaseHeldPort(gw_port_);
     gateway_server_->Start();
 
     http_server_ =
@@ -387,6 +388,7 @@ class ApiRoutesAuthTest : public ::testing::Test {
         *http_server_, session_manager_, agent_loop_, prompt_builder_,
         tool_registry_, config_, *gateway_server_, logger_);
 
+    quantclaw::test::ReleaseHeldPort(http_port_);
     http_server_->Start();
     ASSERT_TRUE(quantclaw::test::WaitForServerReady(http_port_, 5000))
         << "HTTP server not ready on port " << http_port_;
@@ -495,7 +497,7 @@ class ApiRoutesReloadTest : public ::testing::Test {
     gateway_server_ =
         std::make_unique<quantclaw::gateway::GatewayServer>(gw_port_, logger_);
     gateway_server_->SetAuth("none", "");
-    quantclaw::test::ReleaseHeldPorts();
+    quantclaw::test::ReleaseHeldPort(gw_port_);
     gateway_server_->Start();
 
     http_server_ =
@@ -506,6 +508,7 @@ class ApiRoutesReloadTest : public ::testing::Test {
         *http_server_, session_manager_, agent_loop_, prompt_builder_,
         tool_registry_, config_, *gateway_server_, logger_, reload_fn_);
 
+    quantclaw::test::ReleaseHeldPort(http_port_);
     http_server_->Start();
     ASSERT_TRUE(quantclaw::test::WaitForServerReady(http_port_, 5000))
         << "HTTP server not ready on port " << http_port_;
@@ -606,7 +609,7 @@ class ApiGatewayInfoTest : public ::testing::Test {
     gateway_server_ =
         std::make_unique<quantclaw::gateway::GatewayServer>(gw_port_, logger_);
     gateway_server_->SetAuth("none", "");
-    quantclaw::test::ReleaseHeldPorts();
+    quantclaw::test::ReleaseHeldPort(gw_port_);
     gateway_server_->Start();
 
     http_server_ =
@@ -630,6 +633,7 @@ class ApiGatewayInfoTest : public ::testing::Test {
           res.set_content(info.dump(), "application/json");
         });
 
+    quantclaw::test::ReleaseHeldPort(http_port_);
     http_server_->Start();
     ASSERT_TRUE(quantclaw::test::WaitForServerReady(http_port_, 5000))
         << "HTTP server not ready on port " << http_port_;

--- a/tests/test_helpers.hpp
+++ b/tests/test_helpers.hpp
@@ -40,14 +40,14 @@ inline void close_socket(socket_t s) {
 #endif
 }
 
-// Process-wide list of sockets held by FindFreePort().
+// Process-wide list of (port, socket) pairs held by FindFreePort().
 // Guarded by held_mutex().
 inline std::mutex& held_mutex() {
   static std::mutex mu;
   return mu;
 }
-inline std::vector<socket_t>& held_sockets() {
-  static std::vector<socket_t> v;
+inline std::vector<std::pair<int, socket_t>>& held_sockets() {
+  static std::vector<std::pair<int, socket_t>> v;
   return v;
 }
 
@@ -94,7 +94,7 @@ inline int FindFreePort() {
 
     // Keep the socket bound so the OS won't hand this port to another
     // parallel test process.
-    detail::held_sockets().push_back(sock);
+    detail::held_sockets().push_back({port, sock});
     return port;
   }
   return 0;
@@ -108,10 +108,27 @@ inline int FindFreePort() {
 /// TIME_WAIT — the port is immediately reusable.
 inline void ReleaseHeldPorts() {
   std::lock_guard<std::mutex> lock(detail::held_mutex());
-  for (socket_t s : detail::held_sockets()) {
+  for (auto& [port, s] : detail::held_sockets()) {
     detail::close_socket(s);
   }
   detail::held_sockets().clear();
+}
+
+/// Releases the socket held for a specific port.
+///
+/// Use this when you have multiple servers to start sequentially and want to
+/// release each port reservation only immediately before its server binds,
+/// keeping the others reserved to prevent parallel tests from grabbing them.
+inline void ReleaseHeldPort(int port) {
+  std::lock_guard<std::mutex> lock(detail::held_mutex());
+  auto& socks = detail::held_sockets();
+  for (auto it = socks.begin(); it != socks.end(); ++it) {
+    if (it->first == port) {
+      detail::close_socket(it->second);
+      socks.erase(it);
+      return;
+    }
+  }
 }
 
 /// Creates a temporary test directory that is unique to the current process.
@@ -157,11 +174,7 @@ inline bool WaitForServerReady(int port, int timeout_ms = 5000) {
 
     int rc =
         connect(sock, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr));
-#ifdef _WIN32
-    closesocket(sock);
-#else
-    close(sock);
-#endif
+    detail::close_socket(sock);
     if (rc == 0) {
       return true;  // Server is accepting connections
     }

--- a/tests/test_rpc_handlers.cpp
+++ b/tests/test_rpc_handlers.cpp
@@ -655,15 +655,10 @@ TEST_F(RpcHandlersTest, SessionsDeleteExistingReturnsOk) {
   EXPECT_TRUE(result.value("ok", false));
   EXPECT_TRUE(result.value("deleted", false));
 
-  // Verify it's gone
+  // Verify it's gone — fresh fixture has no other sessions, so the list
+  // must be empty after deletion (stronger than searching for a specific key).
   auto list_result = client->Call("sessions.list", nlohmann::json::object());
-  bool found = false;
-  for (const auto& s : list_result["sessions"]) {
-    if (s.value("key", "") == "agent:del:test:main") {
-      found = true;
-    }
-  }
-  EXPECT_FALSE(found);
+  EXPECT_TRUE(list_result["sessions"].empty());
 
   client->Disconnect();
 }

--- a/ui/src/sessions/session-key-utils.test.ts
+++ b/ui/src/sessions/session-key-utils.test.ts
@@ -56,4 +56,12 @@ describe("parseAgentSessionKey", () => {
     expect(result?.agentId).toBe("coder");
     expect(result?.sessionName).toBe("task-42");
   });
+
+  it("returns null for empty agentId segment (agent::session)", () => {
+    expect(parseAgentSessionKey("agent::session")).toBeNull();
+  });
+
+  it("returns null for empty sessionName segment (agent:main:)", () => {
+    expect(parseAgentSessionKey("agent:main:")).toBeNull();
+  });
 });

--- a/ui/src/sessions/session-key-utils.ts
+++ b/ui/src/sessions/session-key-utils.ts
@@ -18,8 +18,8 @@ export function parseAgentSessionKey(
   if (!key) return null;
   const parts = key.split(":");
   if (parts.length < 3 || parts[0] !== "agent") return null;
-  return {
-    agentId: parts[1],
-    sessionName: parts.slice(2).join(":"),
-  };
+  const agentId = parts[1];
+  const sessionName = parts.slice(2).join(":");
+  if (!agentId || !sessionName) return null;
+  return { agentId, sessionName };
 }


### PR DESCRIPTION
## Summary

Addresses all valid code review comments from Copilot and CodeRabbit on PR #56.

- **test_helpers**: add `ReleaseHeldPort(int port)` to release a single port's reservation; store `{port, socket}` pairs; replace platform-specific close with `detail::close_socket` in `WaitForServerReady`
- **test_api_routes**: use `ReleaseHeldPort(gw_port_)` + `ReleaseHeldPort(http_port_)` in all 4 fixtures so the HTTP port reservation is held until immediately before `http_server_->Start()`, eliminating the port-grab race window
- **session-key-utils.ts**: return `null` for empty `agentId` or `sessionName` segments; add 2 new test cases
- **CMakeLists.txt**: explicitly `FORCE`-set `HTTPLIB_REQUIRE_ZLIB OFF` in the else branch to clear stale cache
- **agent_commands.hpp**: guard `SetDefaultTimeoutMs` against non-positive values
- **session_commands.cpp**: guard `block.is_object()` before calling `block.value()`
- **test_rpc_handlers.cpp**: assert `sessions` array is empty after delete instead of searching for wrong key
- **test-cli.sh**: C5.5 — detect timeout exit code 124 as failure; C7.4 — check delete exit code before passing

## Test plan

- [ ] CI passes on this branch
- [ ] After CI green, merge to develop, then update PR #56 (develop→main) and merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)