### PR TITLE
docs: 调整 README 中 UI 构建步骤的顺序

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ quantclaw gateway
 ### 4. Open Dashboard
 
 ```bash
+# Build UI
+./scripts/build_ui.sh
+
+# Open Dashboard
 quantclaw dashboard
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -104,6 +104,10 @@ quantclaw gateway
 ### 4. 打开仪表板
 
 ```bash
+# 打包ui
+./scripts/build_ui.sh
+
+# 打开仪表板
 quantclaw dashboard
 ```
 


### PR DESCRIPTION
### 描述
改动内容：

- 调整 README_CN.md 中"快速开始"章节的步骤顺序
- 将"打包 UI"步骤移至"打开仪表板"之前，确保操作流程更符合逻辑

修改原因： 
当前文档中"打开仪表板"步骤在"打包 UI"之前，这会导致用户在没有构建UI 静态资源的情况下尝试打开仪表板。调整后流程更加合理：

1. 先构建UI (./scripts/build_ui.sh)
2. 再打开仪表板 (quantclaw dashboard)

影响范围：

- 仅文档更新，无代码变更
- 提升新用户的入门体验

检查清单：

- [x] 文档已更新
- [x] 步骤顺序已调整
- [ ] （不适用）代码测试通过
- [x] 中英文 README 保持一致