### PR TITLE
test: use DEFER scope guard for cleanup in test_plugin_system.cpp

### DIFF
--- a/tests/test_plugin_system.cpp
+++ b/tests/test_plugin_system.cpp
@@ -17,6 +17,7 @@
 #include <spdlog/sinks/null_sink.h>
 #include <spdlog/spdlog.h>
 
+#include "quantclaw/common/defer.hpp"
 #include "quantclaw/config.hpp"
 #include "quantclaw/plugins/hook_manager.hpp"
 #include "quantclaw/plugins/plugin_manifest.hpp"
@@ -212,7 +213,7 @@ TEST_F(PluginRegistryTest, DiscoverGlobalPluginsFromPlatformHome) {
   }
 #endif
 
-  auto restore_env = [&]() {
+  DEFER({
 #ifdef _WIN32
     if (!orig_userprofile.empty()) {
       test_setenv("USERPROFILE", orig_userprofile.c_str());
@@ -225,29 +226,21 @@ TEST_F(PluginRegistryTest, DiscoverGlobalPluginsFromPlatformHome) {
     } else {
       test_unsetenv("HOME");
     }
-  };
-
-  try {
-    auto plugin_dir = test_home / ".quantclaw" / "plugins" / "global-plugin";
-    fs::create_directories(plugin_dir);
-    {
-      std::ofstream ofs(plugin_dir / "openclaw.plugin.json");
-      ofs << R"({"id":"global-plugin","name":"Global Plugin"})";
-    }
-
-    quantclaw::PluginRegistry reg(logger_);
-    quantclaw::QuantClawConfig config;
-    reg.Discover(config, test_dir_);
-
-    EXPECT_NE(reg.Find("global-plugin"), nullptr);
-  } catch (...) {
-    restore_env();
     fs::remove_all(test_home);
-    throw;
+  });
+
+  auto plugin_dir = test_home / ".quantclaw" / "plugins" / "global-plugin";
+  fs::create_directories(plugin_dir);
+  {
+    std::ofstream ofs(plugin_dir / "openclaw.plugin.json");
+    ofs << R"({"id":"global-plugin","name":"Global Plugin"})";
   }
 
-  restore_env();
-  fs::remove_all(test_home);
+  quantclaw::PluginRegistry reg(logger_);
+  quantclaw::QuantClawConfig config;
+  reg.Discover(config, test_dir_);
+
+  EXPECT_NE(reg.Find("global-plugin"), nullptr);
 }
 
 TEST_F(PluginRegistryTest, DiscoverPluginsFromConfigPaths) {

--- a/tests/test_plugin_system.cpp
+++ b/tests/test_plugin_system.cpp
@@ -213,7 +213,7 @@ TEST_F(PluginRegistryTest, DiscoverGlobalPluginsFromPlatformHome) {
   }
 #endif
 
-  DEFER({
+  auto cleanup = [&]() {
 #ifdef _WIN32
     if (!orig_userprofile.empty()) {
       test_setenv("USERPROFILE", orig_userprofile.c_str());
@@ -226,8 +226,11 @@ TEST_F(PluginRegistryTest, DiscoverGlobalPluginsFromPlatformHome) {
     } else {
       test_unsetenv("HOME");
     }
-    fs::remove_all(test_home);
-  });
+    std::error_code ec;
+    fs::remove_all(test_home, ec);
+  };
+
+  DEFER(cleanup());
 
   auto plugin_dir = test_home / ".quantclaw" / "plugins" / "global-plugin";
   fs::create_directories(plugin_dir);


### PR DESCRIPTION
## Summary
- Replaced manual try/catch cleanup with DEFER macro in `tests/test_plugin_system.cpp`
- RAII-style automatic cleanup of environment variables and test directories
- Cleaner, more readable test code with less boilerplate

## Test plan
- [x] Verify code compiles correctly
- [x] Ensure cleanup logic is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved plugin-system tests with a guaranteed, scope-exit cleanup so teardown always runs, simplifying control flow and ensuring test artifacts are reliably removed even on failure. This strengthens test robustness and reduces intermittent test flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->