### PR TITLE
test: add agent tool-call regression coverage

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -97,16 +97,7 @@ jobs:
 
     - name: Verify build script
       run: |
-        bash scripts/build.sh
-
-    - name: Configure CMake tests
-      run: |
-        cmake -B build -G Ninja \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_CXX_STANDARD=17 \
-          -DBUILD_TESTS=ON \
-          -DOPENSSL_ROOT_DIR="$(brew --prefix openssl@3)" \
-          -DCURL_ROOT="$(brew --prefix curl)"
+        bash scripts/build.sh --tests
 
     - name: Build tests
       run: cmake --build build --parallel --target quantclaw_tests

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -99,9 +99,6 @@ jobs:
       run: |
         bash scripts/build.sh --tests
 
-    - name: Build tests
-      run: cmake --build build --parallel --target quantclaw_tests
-
     - name: Run unit tests
       working-directory: build
       run: ctest --output-on-failure --parallel --timeout 120

--- a/tests/test_e2e.cpp
+++ b/tests/test_e2e.cpp
@@ -301,7 +301,9 @@ TEST_F(E2ETest, E2E_AgentRequest) {
 TEST_F(E2ETest, E2E_AgentRequestExecutesReadTool) {
   quantclaw::ChatCompletionResponse tool_chunk;
   tool_chunk.tool_calls.push_back(
-      {"call_read_1", "read", {{"path", (workspace_dir_ / "hello.txt").string()}}});
+      {"call_read_1",
+       "read",
+       {{"path", (workspace_dir_ / "hello.txt").string()}}});
 
   quantclaw::ChatCompletionResponse tool_end;
   tool_end.is_stream_end = true;
@@ -343,7 +345,8 @@ TEST_F(E2ETest, E2E_AgentRequestExecutesReadTool) {
                       tool_events_cv.notify_all();
                     });
 
-  auto result = client->Call("agent.request", {{"message", "看一下当前目录有啥"}}, 10000);
+  auto result =
+      client->Call("agent.request", {{"message", "看一下当前目录有啥"}}, 10000);
 
   ASSERT_TRUE(result.contains("response"));
   EXPECT_NE(result["response"].get<std::string>().find("hello world"),
@@ -355,17 +358,17 @@ TEST_F(E2ETest, E2E_AgentRequestExecutesReadTool) {
   std::string observed_tool_content;
   {
     std::unique_lock<std::mutex> lock(tool_events_mutex);
-    const bool got_all_events = tool_events_cv.wait_for(
-        lock, std::chrono::seconds(5),
-        [&] { return got_tool_use && got_tool_result; });
+    const bool got_all_events =
+        tool_events_cv.wait_for(lock, std::chrono::seconds(5), [&] {
+          return got_tool_use && got_tool_result;
+        });
     observed_tool_use = got_tool_use;
     observed_tool_result = got_tool_result;
     observed_tool_name = tool_name;
     observed_tool_content = tool_content;
     ASSERT_TRUE(got_all_events)
         << "Timed out waiting for tool events: got_tool_use="
-        << observed_tool_use
-        << ", got_tool_result=" << observed_tool_result;
+        << observed_tool_use << ", got_tool_result=" << observed_tool_result;
   }
 
   EXPECT_EQ(observed_tool_name, "read");

--- a/tests/test_e2e.cpp
+++ b/tests/test_e2e.cpp
@@ -3,9 +3,11 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <filesystem>
 #include <fstream>
 #include <memory>
+#include <mutex>
 #include <thread>
 
 #include <spdlog/sinks/null_sink.h>
@@ -315,20 +317,30 @@ TEST_F(E2ETest, E2E_AgentRequestExecutesReadTool) {
   auto client = make_client();
   ASSERT_TRUE(client->Connect(5000));
 
-  std::atomic<bool> got_tool_use{false};
-  std::atomic<bool> got_tool_result{false};
+  std::mutex tool_events_mutex;
+  std::condition_variable tool_events_cv;
+  bool got_tool_use = false;
+  bool got_tool_result = false;
   std::string tool_name;
   std::string tool_content;
 
   client->Subscribe("agent.tool_use",
                     [&](const std::string&, const nlohmann::json& payload) {
-                      got_tool_use = true;
-                      tool_name = payload.value("name", "");
+                      {
+                        std::lock_guard<std::mutex> lock(tool_events_mutex);
+                        got_tool_use = true;
+                        tool_name = payload.value("name", "");
+                      }
+                      tool_events_cv.notify_all();
                     });
   client->Subscribe("agent.tool_result",
                     [&](const std::string&, const nlohmann::json& payload) {
-                      got_tool_result = true;
-                      tool_content = payload.value("content", "");
+                      {
+                        std::lock_guard<std::mutex> lock(tool_events_mutex);
+                        got_tool_result = true;
+                        tool_content = payload.value("content", "");
+                      }
+                      tool_events_cv.notify_all();
                     });
 
   auto result = client->Call("agent.request", {{"message", "看一下当前目录有啥"}}, 10000);
@@ -337,11 +349,27 @@ TEST_F(E2ETest, E2E_AgentRequestExecutesReadTool) {
   EXPECT_NE(result["response"].get<std::string>().find("hello world"),
             std::string::npos);
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(500));
-  EXPECT_TRUE(got_tool_use);
-  EXPECT_TRUE(got_tool_result);
-  EXPECT_EQ(tool_name, "read");
-  EXPECT_NE(tool_content.find("hello world"), std::string::npos);
+  bool observed_tool_use = false;
+  bool observed_tool_result = false;
+  std::string observed_tool_name;
+  std::string observed_tool_content;
+  {
+    std::unique_lock<std::mutex> lock(tool_events_mutex);
+    const bool got_all_events = tool_events_cv.wait_for(
+        lock, std::chrono::seconds(5),
+        [&] { return got_tool_use && got_tool_result; });
+    observed_tool_use = got_tool_use;
+    observed_tool_result = got_tool_result;
+    observed_tool_name = tool_name;
+    observed_tool_content = tool_content;
+    ASSERT_TRUE(got_all_events)
+        << "Timed out waiting for tool events: got_tool_use="
+        << observed_tool_use
+        << ", got_tool_result=" << observed_tool_result;
+  }
+
+  EXPECT_EQ(observed_tool_name, "read");
+  EXPECT_NE(observed_tool_content.find("hello world"), std::string::npos);
 
   client->Disconnect();
 }

--- a/tests/test_e2e.cpp
+++ b/tests/test_e2e.cpp
@@ -60,6 +60,8 @@ void register_rpc_handlers(
 class E2EMockLLMProvider : public quantclaw::LLMProvider {
  public:
   std::string response_text = "Hello from QuantClaw E2E mock.";
+  std::vector<std::vector<quantclaw::ChatCompletionResponse>> stream_sequences;
+  size_t stream_sequence_index = 0;
 
   quantclaw::ChatCompletionResponse
   ChatCompletion(const quantclaw::ChatCompletionRequest& /*request*/) override {
@@ -73,6 +75,14 @@ class E2EMockLLMProvider : public quantclaw::LLMProvider {
       const quantclaw::ChatCompletionRequest& /*request*/,
       std::function<void(const quantclaw::ChatCompletionResponse&)> callback)
       override {
+    if (stream_sequence_index < stream_sequences.size()) {
+      for (const auto& chunk : stream_sequences[stream_sequence_index]) {
+        callback(chunk);
+      }
+      ++stream_sequence_index;
+      return;
+    }
+
     // Emit a text delta then stream end
     quantclaw::ChatCompletionResponse delta;
     delta.content = response_text;
@@ -282,6 +292,56 @@ TEST_F(E2ETest, E2E_AgentRequest) {
   // Give events time to arrive
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
   EXPECT_TRUE(got_message_end);
+
+  client->Disconnect();
+}
+
+TEST_F(E2ETest, E2E_AgentRequestExecutesReadTool) {
+  quantclaw::ChatCompletionResponse tool_chunk;
+  tool_chunk.tool_calls.push_back(
+      {"call_read_1", "read", {{"path", (workspace_dir_ / "hello.txt").string()}}});
+
+  quantclaw::ChatCompletionResponse tool_end;
+  tool_end.is_stream_end = true;
+
+  quantclaw::ChatCompletionResponse final_end;
+  final_end.content = "Current directory file content: hello world";
+  final_end.is_stream_end = true;
+  final_end.finish_reason = "stop";
+
+  mock_llm_->stream_sequences = {{tool_chunk, tool_end}, {final_end}};
+  mock_llm_->stream_sequence_index = 0;
+
+  auto client = make_client();
+  ASSERT_TRUE(client->Connect(5000));
+
+  std::atomic<bool> got_tool_use{false};
+  std::atomic<bool> got_tool_result{false};
+  std::string tool_name;
+  std::string tool_content;
+
+  client->Subscribe("agent.tool_use",
+                    [&](const std::string&, const nlohmann::json& payload) {
+                      got_tool_use = true;
+                      tool_name = payload.value("name", "");
+                    });
+  client->Subscribe("agent.tool_result",
+                    [&](const std::string&, const nlohmann::json& payload) {
+                      got_tool_result = true;
+                      tool_content = payload.value("content", "");
+                    });
+
+  auto result = client->Call("agent.request", {{"message", "看一下当前目录有啥"}}, 10000);
+
+  ASSERT_TRUE(result.contains("response"));
+  EXPECT_NE(result["response"].get<std::string>().find("hello world"),
+            std::string::npos);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  EXPECT_TRUE(got_tool_use);
+  EXPECT_TRUE(got_tool_result);
+  EXPECT_EQ(tool_name, "read");
+  EXPECT_NE(tool_content.find("hello world"), std::string::npos);
 
   client->Disconnect();
 }


### PR DESCRIPTION
## 变更
- 基于最新 origin/develop 创建工作分支，并先合入最新 origin/main
- 为 Issue #3 补充 gent.request 的端到端回归测试，覆盖模型发起 ead tool call 并收到结果的链路
- 扩展 E2E mock provider，支持按轮返回流式响应序列，便于稳定复现工具调用场景

## 验证
- uild-win\\quantclaw_tests.exe --gtest_filter=E2ETest.E2E_AgentRequestExecutesReadTool
- uild-win\\quantclaw_tests.exe --gtest_filter=E2ETest.E2E_AgentRequest:ToolRegistryTest.HasToolTrue:PromptBuilderTest.BuildMinimalIncludesTools

## 关联
- Closes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test validating deterministic multi-step streaming, including streamed tool-call events and a final assistant response.

* **Chores**
  * Simplified the macOS CI build workflow to run the build script with tests in a single step for more reliable test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->