### PR TITLE
test: guard stream tool schema regression

### DIFF
--- a/tests/test_agent_loop.cpp
+++ b/tests/test_agent_loop.cpp
@@ -1,6 +1,7 @@
 // Copyright 2025 QuantClaw Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <memory>

--- a/tests/test_agent_loop.cpp
+++ b/tests/test_agent_loop.cpp
@@ -236,6 +236,25 @@ TEST_F(AgentLoopTest, StreamingUsesConfigModel) {
   EXPECT_TRUE(mock_provider_->last_request.stream);
 }
 
+TEST_F(AgentLoopTest, StreamingRequestIncludesBuiltinToolSchemas) {
+  mock_provider_->response_text = "streamed";
+
+  agent_loop_->ProcessMessageStream("test", {}, "sys",
+                                    [](const quantclaw::AgentEvent&) {});
+
+  ASSERT_FALSE(mock_provider_->last_request.tools.empty());
+  EXPECT_TRUE(mock_provider_->last_request.tool_choice_auto);
+
+  const auto has_exec_tool = std::any_of(
+      mock_provider_->last_request.tools.begin(),
+      mock_provider_->last_request.tools.end(), [](const nlohmann::json& tool) {
+        return tool.value("type", "") == "function" &&
+               tool.contains("function") &&
+               tool["function"].value("name", "") == "exec";
+      });
+  EXPECT_TRUE(has_exec_tool);
+}
+
 TEST_F(AgentLoopTest, GetConfigReturnsCurrentConfig) {
   const auto& config = agent_loop_->GetConfig();
   EXPECT_EQ(config.model, "test-model");


### PR DESCRIPTION
## 结论
当前 open PR（#98、#96、#93）都不是在解决 #86。

我核对了最新 main 的代码路径：gent.request -> AgentLoop::ProcessMessageStream -> OpenAIProvider::ChatCompletionStream 已经会把 builtin tool schemas 写进 equest.tools，所以 #86 里日志出现的 	ools_count=0 现象在当前主线上已经不再成立。

## 这次 PR 做了什么
- 为 AgentLoop::ProcessMessageStream 补一条回归测试
- 断言流式请求一定会带上 builtin tool schemas
- 断言 	ool_choice_auto 仍然开启，避免模型退回输出原始 <invoke> 文本

## 验证
- uild-win\\quantclaw_tests.exe --gtest_filter=AgentLoopTest.StreamingRequestIncludesBuiltinToolSchemas:AgentLoopTest.StreamingUsesConfigModel

Closes #86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test to ensure streaming requests include tool schemas, that tool auto-choice is enabled, and at least one built-in tool schema (exec) is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->