### PR TITLE
refactor: hide launchd helper internals

### DIFF
--- a/include/quantclaw/platform/service.hpp
+++ b/include/quantclaw/platform/service.hpp
@@ -5,20 +5,12 @@
 
 #include <memory>
 #include <string>
-#include <string_view>
 
 #include <spdlog/spdlog.h>
 
 #include "quantclaw/constants.hpp"
 
 namespace quantclaw::platform {
-
-#ifdef __APPLE__
-namespace detail {
-std::string shell_quote(std::string_view value);
-std::string xml_escape(std::string_view value);
-}  // namespace detail
-#endif
 
 // Cross-platform daemon/service management.
 // Linux: systemd user service.

--- a/src/platform/service_unix.cpp
+++ b/src/platform/service_unix.cpp
@@ -30,9 +30,9 @@ constexpr const char* kServiceLabel = "com.quantclaw.gateway";
 constexpr const char* kServiceLabel = "quantclaw-gateway";
 #endif
 
-namespace detail {
-
 #ifdef __APPLE__
+namespace {
+
 std::string shell_quote(std::string_view value) {
   std::string quoted = "'";
   for (char ch : value) {
@@ -73,9 +73,8 @@ std::string xml_escape(std::string_view value) {
   }
   return escaped;
 }
+}  // namespace
 #endif
-
-}  // namespace detail
 
 namespace {
 
@@ -140,10 +139,8 @@ std::string launchd_target() {
 }
 
 ExecResult launchd_print_state() {
-  return exec_capture("launchctl print " +
-                          detail::shell_quote(launchd_target()) +
-                          " 2>/dev/null",
-                      5);
+  return exec_capture(
+      "launchctl print " + shell_quote(launchd_target()) + " 2>/dev/null", 5);
 }
 
 bool launchd_is_loaded() {
@@ -153,7 +150,7 @@ bool launchd_is_loaded() {
 int launchd_bootout(std::shared_ptr<spdlog::logger> logger,
                     std::string_view context, bool quiet_if_missing = false) {
   const int ret = std::system(
-      ("launchctl bootout " + detail::shell_quote(launchd_target())).c_str());
+      ("launchctl bootout " + shell_quote(launchd_target())).c_str());
   if (ret != 0 && !(quiet_if_missing && !launchd_is_loaded())) {
     logger->warn("launchctl bootout returned {} during {}", ret, context);
   }
@@ -197,35 +194,35 @@ int ServiceManager::install(int port) {
       << "<plist version=\"1.0\">\n"
       << "<dict>\n"
       << "  <key>Label</key>\n"
-      << "  <string>" << detail::xml_escape(kServiceLabel) << "</string>\n"
+      << "  <string>" << xml_escape(kServiceLabel) << "</string>\n"
       << "  <key>ProgramArguments</key>\n"
       << "  <array>\n"
-      << "    <string>" << detail::xml_escape(exe) << "</string>\n"
+      << "    <string>" << xml_escape(exe) << "</string>\n"
       << "    <string>gateway</string>\n"
       << "    <string>run</string>\n"
       << "    <string>--port</string>\n"
       << "    <string>" << port << "</string>\n"
       << "  </array>\n"
       << "  <key>WorkingDirectory</key>\n"
-      << "  <string>" << detail::xml_escape(state_dir_) << "</string>\n"
+      << "  <string>" << xml_escape(state_dir_) << "</string>\n"
       << "  <key>RunAtLoad</key>\n"
       << "  <true/>\n"
       << "  <key>KeepAlive</key>\n"
       << "  <true/>\n"
       << "  <key>StandardOutPath</key>\n"
-      << "  <string>" << detail::xml_escape(log_file_) << "</string>\n"
+      << "  <string>" << xml_escape(log_file_) << "</string>\n"
       << "  <key>StandardErrorPath</key>\n"
-      << "  <string>" << detail::xml_escape(log_file_) << "</string>\n"
+      << "  <string>" << xml_escape(log_file_) << "</string>\n"
       << "  <key>EnvironmentVariables</key>\n"
       << "  <dict>\n"
       << "    <key>HOME</key>\n"
-      << "    <string>" << detail::xml_escape(home_directory()) << "</string>\n"
+      << "    <string>" << xml_escape(home_directory()) << "</string>\n"
       << "    <key>PATH</key>\n"
       << "    <string>"
-      << detail::xml_escape(std::getenv("PATH")
-                                ? std::getenv("PATH")
-                                : "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/"
-                                  "bin:/opt/homebrew/bin")
+      << xml_escape(std::getenv("PATH")
+                        ? std::getenv("PATH")
+                        : "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/"
+                          "bin:/opt/homebrew/bin")
       << "</string>\n"
       << "    <key>QUANTCLAW_LOG_LEVEL</key>\n"
       << "    <string>info</string>\n"
@@ -328,8 +325,7 @@ int ServiceManager::start() {
   }
 
   int ret = std::system(("launchctl bootstrap " +
-                         detail::shell_quote(launchd_domain()) + " " +
-                         detail::shell_quote(svc))
+                         shell_quote(launchd_domain()) + " " + shell_quote(svc))
                             .c_str());
   if (ret != 0) {
     if (!launchd_is_loaded()) {
@@ -342,8 +338,7 @@ int ServiceManager::start() {
         ret);
   }
 
-  ret = std::system(
-      ("launchctl kickstart -k " + detail::shell_quote(target)).c_str());
+  ret = std::system(("launchctl kickstart -k " + shell_quote(target)).c_str());
   if (ret == 0) {
     logger_->info("Gateway started via launchd");
   } else {
@@ -365,8 +360,7 @@ int ServiceManager::start() {
 int ServiceManager::stop() {
 #ifdef __APPLE__
   auto target = launchd_target();
-  int ret =
-      std::system(("launchctl bootout " + detail::shell_quote(target)).c_str());
+  int ret = std::system(("launchctl bootout " + shell_quote(target)).c_str());
   if (ret == 0) {
     logger_->info("Gateway stopped");
     remove_pid();

--- a/src/platform/service_unix.cpp
+++ b/src/platform/service_unix.cpp
@@ -33,6 +33,9 @@ constexpr const char* kServiceLabel = "quantclaw-gateway";
 #ifdef __APPLE__
 namespace {
 
+constexpr std::string_view kDefaultLaunchdPath =
+    "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/opt/homebrew/bin";
+
 std::string shell_quote(std::string_view value) {
   std::string quoted = "'";
   for (char ch : value) {
@@ -218,12 +221,7 @@ int ServiceManager::install(int port) {
       << "    <key>HOME</key>\n"
       << "    <string>" << xml_escape(home_directory()) << "</string>\n"
       << "    <key>PATH</key>\n"
-      << "    <string>"
-      << xml_escape(std::getenv("PATH")
-                        ? std::getenv("PATH")
-                        : "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/"
-                          "bin:/opt/homebrew/bin")
-      << "</string>\n"
+      << "    <string>" << xml_escape(kDefaultLaunchdPath) << "</string>\n"
       << "    <key>QUANTCLAW_LOG_LEVEL</key>\n"
       << "    <string>info</string>\n"
       << "  </dict>\n"

--- a/tests/test_platform.cpp
+++ b/tests/test_platform.cpp
@@ -221,27 +221,3 @@ TEST(PlatformService, WritePidFile) {
   svc.remove_pid();
   EXPECT_EQ(svc.get_pid(), -1);
 }
-
-#ifdef __APPLE__
-TEST(PlatformService, ShellQuoteHandlesEmptyString) {
-  EXPECT_EQ(quantclaw::platform::detail::shell_quote(""), "''");
-}
-
-TEST(PlatformService, ShellQuoteEscapesSingleQuotesInPaths) {
-  EXPECT_EQ(
-      quantclaw::platform::detail::shell_quote("/tmp/O'Reilly & Sons/gateway"),
-      "'/tmp/O'\\''Reilly & Sons/gateway'");
-}
-
-TEST(PlatformService, XmlEscapeHandlesEmptyString) {
-  EXPECT_EQ(quantclaw::platform::detail::xml_escape(""), "");
-}
-
-TEST(PlatformService, XmlEscapeEscapesXmlSpecialCharacters) {
-  EXPECT_EQ(quantclaw::platform::detail::xml_escape("&<>\"'"),
-            "&amp;&lt;&gt;&quot;&apos;");
-  EXPECT_EQ(
-      quantclaw::platform::detail::xml_escape("/tmp/O'Reilly & Sons/<gateway>"),
-      "/tmp/O&apos;Reilly &amp; Sons/&lt;gateway&gt;");
-}
-#endif


### PR DESCRIPTION
## 变更
- 从公共头 include/quantclaw/platform/service.hpp 移除 macOS 专用的 shell_quote() / xml_escape() 声明
- 将这两个 launchd helper 收回 src/platform/service_unix.cpp 的文件内部匿名命名空间
- 更新 macOS 调用点，保持行为不变，只缩小 API 暴露面

## 验证
- uild-win\\quantclaw_tests.exe --gtest_filter=ProtocolTest.*
- uild-win\\quantclaw_tests.exe --gtest_filter=PlatformTest.*:DaemonManagerTest.*
- 额外确认仓库里已不存在 detail::shell_quote / detail::xml_escape 的外部引用

Closes #87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal reorganization of Apple/macOS platform service code with no user-facing behavior changes.
* **Tests**
  * Removed Apple-specific unit tests related to internal helper utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->