### PR TITLE
feat: normalize fragmented OpenAI tool calls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,7 @@ set(QUANTCLAW_CORE_SOURCES
     src/providers/github_copilot_provider.cpp
     src/providers/anthropic_provider.cpp
     src/providers/provider_registry.cpp
+    src/providers/stream_normalization.cpp
     src/providers/provider_error.cpp
     src/providers/cooldown_tracker.cpp
     src/providers/failover_resolver.cpp

--- a/include/quantclaw/providers/openai_provider.hpp
+++ b/include/quantclaw/providers/openai_provider.hpp
@@ -17,7 +17,9 @@ namespace quantclaw {
 class OpenAIProvider : public LLMProvider {
  public:
   OpenAIProvider(const std::string& api_key, const std::string& base_url,
-                 int timeout, std::shared_ptr<spdlog::logger> logger);
+                 int timeout, std::shared_ptr<spdlog::logger> logger,
+                 std::string provider_id = "openai",
+                 std::string api = "openai-completions");
 
   ChatCompletionResponse
   ChatCompletion(const ChatCompletionRequest& request) override;
@@ -39,6 +41,8 @@ class OpenAIProvider : public LLMProvider {
   std::string base_url_;
   int timeout_;
   std::shared_ptr<spdlog::logger> logger_;
+  std::string provider_id_;
+  std::string api_;
 };
 
 }  // namespace quantclaw

--- a/include/quantclaw/providers/stream_normalization.hpp
+++ b/include/quantclaw/providers/stream_normalization.hpp
@@ -1,0 +1,57 @@
+// Copyright 2025 QuantClaw Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+#include <spdlog/spdlog.h>
+
+#include "quantclaw/providers/llm_provider.hpp"
+
+namespace quantclaw {
+
+struct StreamNormalizationContext {
+  std::string provider_id;
+  std::string api;
+  std::vector<std::string> allowed_tool_names;
+  std::unordered_map<std::string, std::string> normalized_allowed_tool_names;
+  std::unordered_map<std::string, std::string> folded_allowed_tool_names;
+  bool decode_html_entities = false;
+  std::shared_ptr<spdlog::logger> logger;
+};
+
+struct PendingToolCallFragment {
+  size_t index = 0;
+  std::string id;
+  std::string name;
+  std::string arguments;
+};
+
+std::vector<std::string>
+ExtractAllowedToolNames(const ChatCompletionRequest& request);
+
+StreamNormalizationContext BuildStreamNormalizationContext(
+    const std::string& provider_id, const std::string& api,
+    const ChatCompletionRequest& request,
+    const std::shared_ptr<spdlog::logger>& logger);
+
+void SanitizeReplayMessages(std::vector<Message>* messages,
+                            const StreamNormalizationContext& context);
+
+void NormalizeToolCalls(std::vector<ToolCall>* tool_calls,
+                        const StreamNormalizationContext& context,
+                        std::unordered_set<std::string>* seen_ids = nullptr);
+
+std::vector<ToolCall> FinalizePendingToolCalls(
+    const std::vector<PendingToolCallFragment>& pending,
+    const StreamNormalizationContext& context,
+    std::unordered_set<std::string>* seen_ids = nullptr,
+    std::vector<PendingToolCallFragment>* remaining = nullptr);
+
+}  // namespace quantclaw

--- a/src/adapters/package-lock.json
+++ b/src/adapters/package-lock.json
@@ -8,12 +8,13 @@
       "name": "@quantclaw/adapters",
       "version": "0.2.0",
       "dependencies": {
+        "@larksuiteoapi/node-sdk": "^1.30.0",
         "discord.js": "^14.16.0",
         "telegraf": "^4.16.0",
         "ws": "^8.18.0"
       },
       "devDependencies": {
-        "@types/node": "^22.0.0",
+        "@types/node": "^25.4.0",
         "@types/ws": "^8.5.0",
         "tsx": "^4.19.0",
         "typescript": "^5.6.0"
@@ -591,6 +592,85 @@
         "node": ">=18"
       }
     },
+    "node_modules/@larksuiteoapi/node-sdk": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@larksuiteoapi/node-sdk/-/node-sdk-1.60.0.tgz",
+      "integrity": "sha512-MS1eXx7K6HHIyIcCBkJLb21okoa8ZatUGQWZaCCUePm6a37RWFmT6ZKlKvHxAanSX26wNuNlwP0RhgscsE+T6g==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "~1.13.3",
+        "lodash.identity": "^3.0.0",
+        "lodash.merge": "^4.6.2",
+        "lodash.pickby": "^4.6.0",
+        "protobufjs": "^7.2.6",
+        "qs": "^6.14.2",
+        "ws": "^8.19.0"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@sapphire/async-queue": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
@@ -631,12 +711,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
-      "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/ws": {
@@ -670,6 +750,23 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/buffer-alloc": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
@@ -692,6 +789,47 @@
       "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
       "license": "MIT"
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -707,6 +845,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/discord-api-types": {
@@ -743,6 +890,65 @@
       },
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -802,6 +1008,42 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -817,6 +1059,52 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
@@ -830,10 +1118,79 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.identity": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-3.0.0.tgz",
+      "integrity": "sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.pickby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
+      "integrity": "sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==",
       "license": "MIT"
     },
     "node_modules/lodash.snakecase": {
@@ -842,11 +1199,47 @@
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/magic-bytes.js": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
       "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
       "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -883,6 +1276,18 @@
         }
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/p-timeout": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
@@ -890,6 +1295,51 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -918,6 +1368,78 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/telegraf": {
@@ -1004,9 +1526,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/webidl-conversions": {

--- a/src/core/agent_loop.cpp
+++ b/src/core/agent_loop.cpp
@@ -311,8 +311,9 @@ std::vector<Message> AgentLoop::ProcessMessage(
         continue;
       }
 
-      if (saw_invalid_tool_call && !has_non_whitespace(response.content)) {
-        logger_->error("LLM returned only invalid tool calls");
+      if (saw_invalid_tool_call && !has_non_whitespace(response.content) &&
+          valid_tool_calls.empty()) {
+        logger_->error("LLM returned only invalid tool calls after normalization");
         Message final_msg;
         final_msg.role = "assistant";
         final_msg.content.push_back(
@@ -506,7 +507,8 @@ std::vector<Message> AgentLoop::ProcessMessageStream(
               auto valid_tool_calls = filter_valid_tool_calls(
                   chunk.tool_calls, logger_, &chunk_has_invalid);
               saw_invalid_tool_call =
-                  saw_invalid_tool_call || chunk_has_invalid;
+                  saw_invalid_tool_call ||
+                  (chunk_has_invalid && valid_tool_calls.empty());
               if (valid_tool_calls.empty()) {
                 return;
               }

--- a/src/providers/openai_provider.cpp
+++ b/src/providers/openai_provider.cpp
@@ -7,12 +7,14 @@
 #include <cctype>
 #include <sstream>
 #include <string_view>
+#include <unordered_set>
 
 #include <curl/curl.h>
 #include <nlohmann/json.hpp>
 #include <spdlog/spdlog.h>
 
 #include "quantclaw/providers/provider_error.hpp"
+#include "quantclaw/providers/stream_normalization.hpp"
 
 namespace quantclaw {
 
@@ -214,11 +216,14 @@ std::string SummarizeErrorBodyForLog(std::string_view body) {
 
 OpenAIProvider::OpenAIProvider(const std::string& api_key,
                                const std::string& base_url, int timeout,
-                               std::shared_ptr<spdlog::logger> logger)
+                               std::shared_ptr<spdlog::logger> logger,
+                               std::string provider_id, std::string api)
     : api_key_(api_key),
       base_url_(base_url),
       timeout_(timeout),
-      logger_(logger) {
+      logger_(logger),
+      provider_id_(std::move(provider_id)),
+      api_(std::move(api)) {
   if (base_url_.empty()) {
     base_url_ = "https://api.openai.com/v1";
   }
@@ -235,11 +240,16 @@ std::string OpenAIProvider::ResolveBaseUrl() const {
 }
 
 std::string OpenAIProvider::ProviderId() const {
-  return "openai";
+  return provider_id_;
 }
 
 ChatCompletionResponse
 OpenAIProvider::ChatCompletion(const ChatCompletionRequest& request) {
+  auto normalized_messages = request.messages;
+  const auto normalization_context =
+      BuildStreamNormalizationContext(ProviderId(), api_, request, logger_);
+  SanitizeReplayMessages(&normalized_messages, normalization_context);
+
   // Build JSON payload
   nlohmann::json payload;
   payload["model"] = request.model;
@@ -248,7 +258,7 @@ OpenAIProvider::ChatCompletion(const ChatCompletionRequest& request) {
 
   // Add messages
   payload["messages"] =
-      serialize_messages_to_openai(request.messages, request.thinking != "off");
+      serialize_messages_to_openai(normalized_messages, request.thinking != "off");
 
   // Add tools if provided
   if (!request.tools.empty()) {
@@ -286,12 +296,18 @@ OpenAIProvider::ChatCompletion(const ChatCompletionRequest& request) {
           if (tc.contains("function")) {
             tool_call.name = tc["function"].value("name", "");
             if (tc["function"].contains("arguments")) {
-              auto args_str = tc["function"]["arguments"].get<std::string>();
-              tool_call.arguments = nlohmann::json::parse(args_str);
+              const auto& args = tc["function"]["arguments"];
+              if (args.is_string()) {
+                tool_call.arguments =
+                    nlohmann::json::parse(args.get<std::string>(), nullptr, false);
+              } else {
+                tool_call.arguments = args;
+              }
             }
           }
-          result.tool_calls.push_back(tool_call);
+          result.tool_calls.push_back(std::move(tool_call));
         }
+        NormalizeToolCalls(&result.tool_calls, normalization_context);
       }
     }
     if (choice.contains("finish_reason")) {
@@ -382,53 +398,30 @@ struct StreamContext {
   std::string buffer;  // incomplete line across chunks
   std::string raw_response_body;
   std::shared_ptr<spdlog::logger> logger;
+  StreamNormalizationContext normalization_context;
+  std::unordered_set<std::string> seen_tool_call_ids;
 
-  // Accumulated tool calls (SSE delivers them in fragments)
-  struct PendingToolCall {
-    std::string id;
-    std::string name;
-    std::string arguments;
-  };
-  std::vector<PendingToolCall> pending_tool_calls;
+  std::vector<PendingToolCallFragment> pending_tool_calls;
 };
 
-static bool HasNonWhitespace(const std::string& value) {
-  return std::any_of(value.begin(), value.end(),
-                     [](unsigned char ch) { return !std::isspace(ch); });
-}
-
 static std::vector<ToolCall> TakeCompleteToolCalls(StreamContext* ctx,
-                                                   bool drop_incomplete) {
-  std::vector<ToolCall> complete;
-  std::vector<StreamContext::PendingToolCall> remaining;
+                                                   bool keep_incomplete) {
+  std::vector<PendingToolCallFragment> remaining;
+  auto complete = FinalizePendingToolCalls(ctx->pending_tool_calls,
+                                           ctx->normalization_context,
+                                           &ctx->seen_tool_call_ids,
+                                           &remaining);
 
-  for (const auto& pending : ctx->pending_tool_calls) {
-    nlohmann::json parsed_arguments = nlohmann::json::object();
-    bool invalid_arguments = false;
-    if (HasNonWhitespace(pending.arguments)) {
-      parsed_arguments =
-          nlohmann::json::parse(pending.arguments, nullptr, false);
-      invalid_arguments = parsed_arguments.is_discarded();
-    }
-
-    if (pending.id.empty() || !HasNonWhitespace(pending.name) ||
-        invalid_arguments) {
-      if (!drop_incomplete) {
-        remaining.push_back(pending);
-      } else if (ctx->logger) {
+  if (!keep_incomplete) {
+    for (const auto& pending : remaining) {
+      if (ctx->logger) {
         ctx->logger->warn(
-            "Dropping incomplete streamed tool call: id='{}', name='{}', "
-            "arguments_len={}",
+            "Dropping incomplete streamed tool call: id='{}', name='{}', arguments_len={}",
             pending.id, pending.name, pending.arguments.size());
       }
-      continue;
     }
-
-    ToolCall tc;
-    tc.id = pending.id;
-    tc.name = pending.name;
-    tc.arguments = std::move(parsed_arguments);
-    complete.push_back(std::move(tc));
+    ctx->pending_tool_calls.clear();
+    return complete;
   }
 
   ctx->pending_tool_calls = std::move(remaining);
@@ -463,7 +456,7 @@ static size_t StreamWriteCallback(void* contents, size_t size, size_t nmemb,
     if (data == "[DONE]") {
       // Emit any accumulated tool calls before stream end
       if (!ctx->pending_tool_calls.empty()) {
-        auto complete = TakeCompleteToolCalls(ctx, true);
+        auto complete = TakeCompleteToolCalls(ctx, false);
         ChatCompletionResponse tc_resp;
         tc_resp.finish_reason = "tool_calls";
         tc_resp.tool_calls = std::move(complete);
@@ -526,7 +519,8 @@ static size_t StreamWriteCallback(void* contents, size_t size, size_t nmemb,
           ctx->pending_tool_calls.push_back({});
         }
 
-        auto& ptc = ctx->pending_tool_calls[index];
+        auto& ptc = ctx->pending_tool_calls[tool_index];
+        ptc.index = tool_index;
         if (tc_delta.contains("id") && !tc_delta["id"].is_null()) {
           ptc.id = tc_delta["id"].get<std::string>();
         }
@@ -544,7 +538,7 @@ static size_t StreamWriteCallback(void* contents, size_t size, size_t nmemb,
 
     // If finish_reason is "tool_calls", emit accumulated tool calls now
     if (finish_reason == "tool_calls" && !ctx->pending_tool_calls.empty()) {
-      auto complete = TakeCompleteToolCalls(ctx, false);
+      auto complete = TakeCompleteToolCalls(ctx, true);
       ChatCompletionResponse tc_resp;
       tc_resp.finish_reason = "tool_calls";
       tc_resp.tool_calls = std::move(complete);
@@ -560,6 +554,11 @@ static size_t StreamWriteCallback(void* contents, size_t size, size_t nmemb,
 void OpenAIProvider::ChatCompletionStream(
     const ChatCompletionRequest& request,
     std::function<void(const ChatCompletionResponse&)> callback) {
+  auto normalized_messages = request.messages;
+  const auto normalization_context =
+      BuildStreamNormalizationContext(ProviderId(), api_, request, logger_);
+  SanitizeReplayMessages(&normalized_messages, normalization_context);
+
   // Build JSON payload with stream=true
   nlohmann::json payload;
   payload["model"] = request.model;
@@ -568,7 +567,7 @@ void OpenAIProvider::ChatCompletionStream(
   payload["stream"] = true;
 
   payload["messages"] =
-      serialize_messages_to_openai(request.messages, request.thinking != "off");
+      serialize_messages_to_openai(normalized_messages, request.thinking != "off");
 
   if (!request.tools.empty()) {
     payload["tools"] = request.tools;
@@ -583,6 +582,7 @@ void OpenAIProvider::ChatCompletionStream(
   StreamContext stream_ctx;
   stream_ctx.callback = callback;
   stream_ctx.logger = logger_;
+  stream_ctx.normalization_context = normalization_context;
 
   RetryAfterCapture retry_capture;
 

--- a/src/providers/provider_registry.cpp
+++ b/src/providers/provider_registry.cpp
@@ -4,6 +4,7 @@
 #include "quantclaw/providers/provider_registry.hpp"
 
 #include <algorithm>
+#include <string_view>
 
 #include "quantclaw/auth/github_copilot_auth.hpp"
 #include "quantclaw/auth/openai_codex_auth.hpp"
@@ -13,6 +14,47 @@
 #include "quantclaw/providers/openai_provider.hpp"
 
 namespace quantclaw {
+namespace {
+
+std::string NormalizeProviderApi(const ProviderEntry& entry,
+                                 std::string_view fallback_api) {
+  if (!entry.api.empty()) {
+    return entry.api;
+  }
+  return std::string(fallback_api);
+}
+
+std::string ResolveFactoryIdForEntry(const ProviderEntry& entry) {
+  if (!entry.api.empty()) {
+    if (entry.api == "anthropic-messages") {
+      return "anthropic";
+    }
+    if (entry.api == "google-generative-ai") {
+      return "gemini";
+    }
+    if (entry.api == "openai-codex-responses") {
+      return "openai-codex";
+    }
+    if (entry.api == "openai-completions" || entry.api == "openai-responses" ||
+        entry.api == "azure-openai-responses") {
+      return "openai";
+    }
+  }
+  return entry.id;
+}
+
+std::shared_ptr<LLMProvider> CreateOpenAICompatibleProvider(
+    const ProviderEntry& entry, std::shared_ptr<spdlog::logger> logger,
+    std::string_view default_base_url, std::string_view default_api) {
+  std::string url = entry.base_url.empty() ? std::string(default_base_url)
+                                           : entry.base_url;
+  return std::make_shared<OpenAIProvider>(entry.api_key, url, entry.timeout,
+                                          std::move(logger), entry.id,
+                                          NormalizeProviderApi(entry, default_api));
+}
+
+}  // namespace
+
 // --- ModelRef ---
 
 ModelRef ModelRef::parse(const std::string& raw,
@@ -43,10 +85,9 @@ void ProviderRegistry::RegisterBuiltinFactories() {
   // OpenAI-compatible factory (also works for Ollama, Together, etc.)
   RegisterFactory("openai", [](const ProviderEntry& entry,
                                std::shared_ptr<spdlog::logger> logger) {
-    std::string url =
-        entry.base_url.empty() ? "https://api.openai.com/v1" : entry.base_url;
-    return std::make_shared<OpenAIProvider>(entry.api_key, url, entry.timeout,
-                                            logger);
+    return CreateOpenAICompatibleProvider(entry, std::move(logger),
+                                          "https://api.openai.com/v1",
+                                          "openai-completions");
   });
 
   RegisterFactory("openai-codex", [](const ProviderEntry& entry,
@@ -87,21 +128,18 @@ void ProviderRegistry::RegisterBuiltinFactories() {
   // Ollama (uses OpenAI-compatible API)
   RegisterFactory("ollama", [](const ProviderEntry& entry,
                                std::shared_ptr<spdlog::logger> logger) {
-    std::string url =
-        entry.base_url.empty() ? "http://localhost:11434/v1" : entry.base_url;
-    return std::make_shared<OpenAIProvider>(entry.api_key, url, entry.timeout,
-                                            logger);
+    return CreateOpenAICompatibleProvider(entry, std::move(logger),
+                                          "http://localhost:11434/v1",
+                                          "openai-completions");
   });
 
   // Gemini / Google (uses OpenAI-compatible API via base_url override)
   RegisterFactory("gemini", [](const ProviderEntry& entry,
                                std::shared_ptr<spdlog::logger> logger) {
-    std::string url =
-        entry.base_url.empty()
-            ? "https://generativelanguage.googleapis.com/v1beta/openai"
-            : entry.base_url;
-    return std::make_shared<OpenAIProvider>(entry.api_key, url, entry.timeout,
-                                            logger);
+    return CreateOpenAICompatibleProvider(
+        entry, std::move(logger),
+        "https://generativelanguage.googleapis.com/v1beta/openai",
+        "google-generative-ai");
   });
 
   // Google alias
@@ -110,28 +148,25 @@ void ProviderRegistry::RegisterBuiltinFactories() {
   // Bedrock (uses OpenAI-compatible gateway)
   RegisterFactory("bedrock", [](const ProviderEntry& entry,
                                 std::shared_ptr<spdlog::logger> logger) {
-    std::string url =
-        entry.base_url.empty() ? "http://localhost:8080/v1" : entry.base_url;
-    return std::make_shared<OpenAIProvider>(entry.api_key, url, entry.timeout,
-                                            logger);
+    return CreateOpenAICompatibleProvider(entry, std::move(logger),
+                                          "http://localhost:8080/v1",
+                                          "openai-completions");
   });
 
   // OpenRouter
   RegisterFactory("openrouter", [](const ProviderEntry& entry,
                                    std::shared_ptr<spdlog::logger> logger) {
-    std::string url = entry.base_url.empty() ? "https://openrouter.ai/api/v1"
-                                             : entry.base_url;
-    return std::make_shared<OpenAIProvider>(entry.api_key, url, entry.timeout,
-                                            logger);
+    return CreateOpenAICompatibleProvider(entry, std::move(logger),
+                                          "https://openrouter.ai/api/v1",
+                                          "openai-completions");
   });
 
   // Together
   RegisterFactory("together", [](const ProviderEntry& entry,
                                  std::shared_ptr<spdlog::logger> logger) {
-    std::string url =
-        entry.base_url.empty() ? "https://api.together.xyz/v1" : entry.base_url;
-    return std::make_shared<OpenAIProvider>(entry.api_key, url, entry.timeout,
-                                            logger);
+    return CreateOpenAICompatibleProvider(entry, std::move(logger),
+                                          "https://api.together.xyz/v1",
+                                          "openai-completions");
   });
 }
 
@@ -164,6 +199,7 @@ void ProviderRegistry::LoadFromConfig(const nlohmann::json& providers_json) {
     if (entry.api_key_env.empty()) {
       entry.api_key_env = val.value("api_key_env", std::string{});
     }
+    entry.api = val.value("api", std::string{});
     entry.timeout = val.value("timeout", 30);
     if (val.contains("extra")) {
       entry.extra = val["extra"];
@@ -210,13 +246,6 @@ ProviderRegistry::GetProvider(const std::string& provider_id) {
   if (it != instances_.end())
     return it->second;
 
-  // Find factory
-  auto fit = factories_.find(provider_id);
-  if (fit == factories_.end()) {
-    logger_->error("No factory registered for provider: {}", provider_id);
-    return nullptr;
-  }
-
   // Find entry
   auto eit = entries_.find(provider_id);
   if (eit == entries_.end()) {
@@ -226,6 +255,15 @@ ProviderRegistry::GetProvider(const std::string& provider_id) {
     entry.api_key = resolve_api_key(entry);
     entries_[provider_id] = entry;
     eit = entries_.find(provider_id);
+  }
+
+  auto factory_id = ResolveFactoryIdForEntry(eit->second);
+  auto fit = factories_.find(factory_id);
+  if (fit == factories_.end()) {
+    logger_->error(
+        "No factory registered for provider: {} (resolved from {} with api={})",
+        factory_id, provider_id, eit->second.api);
+    return nullptr;
   }
 
   auto provider = fit->second(eit->second, logger_);
@@ -241,12 +279,6 @@ ProviderRegistry::GetProviderForModel(const ModelRef& ref) {
 std::shared_ptr<LLMProvider>
 ProviderRegistry::GetProviderWithKey(const std::string& provider_id,
                                      const std::string& api_key) {
-  auto fit = factories_.find(provider_id);
-  if (fit == factories_.end()) {
-    logger_->error("No factory for provider: {}", provider_id);
-    return nullptr;
-  }
-
   // Build a temporary entry with the given API key
   ProviderEntry entry;
   auto eit = entries_.find(provider_id);
@@ -256,6 +288,14 @@ ProviderRegistry::GetProviderWithKey(const std::string& provider_id,
     entry.id = provider_id;
   }
   entry.api_key = api_key;
+
+  auto factory_id = ResolveFactoryIdForEntry(entry);
+  auto fit = factories_.find(factory_id);
+  if (fit == factories_.end()) {
+    logger_->error("No factory for provider: {} (resolved from {} with api={})",
+                   factory_id, provider_id, entry.api);
+    return nullptr;
+  }
 
   return fit->second(entry, logger_);
 }
@@ -278,7 +318,11 @@ std::vector<ModelAlias> ProviderRegistry::Aliases() const {
 }
 
 bool ProviderRegistry::HasProvider(const std::string& provider_id) const {
-  return factories_.count(provider_id) > 0 || entries_.count(provider_id) > 0;
+  if (entries_.count(provider_id) > 0) {
+    const auto& entry = entries_.at(provider_id);
+    return factories_.count(ResolveFactoryIdForEntry(entry)) > 0;
+  }
+  return factories_.count(provider_id) > 0;
 }
 
 const ProviderEntry*

--- a/src/providers/stream_normalization.cpp
+++ b/src/providers/stream_normalization.cpp
@@ -1,0 +1,648 @@
+// Copyright 2025 QuantClaw Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "quantclaw/providers/stream_normalization.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <optional>
+#include <regex>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+
+#include "quantclaw/common/string_util.hpp"
+#include "quantclaw/core/content_block.hpp"
+
+namespace quantclaw {
+namespace {
+
+constexpr size_t kReplayToolCallNameMaxChars = 64;
+
+bool HasNonWhitespace(std::string_view value) {
+  return std::any_of(value.begin(), value.end(), [](unsigned char ch) {
+    return !std::isspace(ch);
+  });
+}
+
+std::string NormalizeToolNameToken(std::string_view raw) {
+  std::string normalized;
+  normalized.reserve(raw.size());
+  bool last_was_separator = false;
+  for (unsigned char ch : raw) {
+    if (std::isalnum(ch)) {
+      normalized.push_back(static_cast<char>(std::tolower(ch)));
+      last_was_separator = false;
+      continue;
+    }
+    if (ch == '.' || ch == '_' || ch == '-' || ch == '/') {
+      if (!last_was_separator && !normalized.empty()) {
+        normalized.push_back('.');
+      }
+      last_was_separator = true;
+    }
+  }
+  while (!normalized.empty() && normalized.back() == '.') {
+    normalized.pop_back();
+  }
+  return normalized;
+}
+
+const std::unordered_map<std::string, std::string>& HtmlEntityMap() {
+  static const auto* entities =
+      new std::unordered_map<std::string, std::string>{{"amp", "&"},
+                                                       {"quot", "\""},
+                                                       {"apos", "'"},
+                                                       {"#39", "'"},
+                                                       {"lt", "<"},
+                                                       {"gt", ">"}};
+  return *entities;
+}
+
+std::optional<std::string> DecodeHtmlEntity(std::string_view entity) {
+  const auto& entities = HtmlEntityMap();
+  auto it = entities.find(std::string(entity));
+  if (it != entities.end()) {
+    return it->second;
+  }
+
+  if (entity.size() >= 2 && entity[0] == '#') {
+    int codepoint = -1;
+    try {
+      if (entity[1] == 'x' || entity[1] == 'X') {
+        codepoint = std::stoi(std::string(entity.substr(2)), nullptr, 16);
+      } else {
+        codepoint = std::stoi(std::string(entity.substr(1)), nullptr, 10);
+      }
+    } catch (...) {
+      return std::nullopt;
+    }
+    if (codepoint < 0 || codepoint > 0x10FFFF) {
+      return std::nullopt;
+    }
+    std::string decoded;
+    if (codepoint <= 0x7F) {
+      decoded.push_back(static_cast<char>(codepoint));
+    } else if (codepoint <= 0x7FF) {
+      decoded.push_back(static_cast<char>(0xC0 | ((codepoint >> 6) & 0x1F)));
+      decoded.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+    } else if (codepoint <= 0xFFFF) {
+      decoded.push_back(static_cast<char>(0xE0 | ((codepoint >> 12) & 0x0F)));
+      decoded.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
+      decoded.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+    } else {
+      decoded.push_back(static_cast<char>(0xF0 | ((codepoint >> 18) & 0x07)));
+      decoded.push_back(static_cast<char>(0x80 | ((codepoint >> 12) & 0x3F)));
+      decoded.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
+      decoded.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+    }
+    return decoded;
+  }
+
+  return std::nullopt;
+}
+
+std::string DecodeHtmlEntities(std::string_view raw) {
+  std::string decoded;
+  decoded.reserve(raw.size());
+  for (size_t i = 0; i < raw.size(); ++i) {
+    if (raw[i] != '&') {
+      decoded.push_back(raw[i]);
+      continue;
+    }
+    const auto semi = raw.find(';', i + 1);
+    if (semi == std::string_view::npos) {
+      decoded.push_back(raw[i]);
+      continue;
+    }
+    const auto entity = raw.substr(i + 1, semi - i - 1);
+    auto replacement = DecodeHtmlEntity(entity);
+    if (!replacement) {
+      decoded.push_back(raw[i]);
+      continue;
+    }
+    decoded += *replacement;
+    i = semi;
+  }
+  return decoded;
+}
+
+void DecodeHtmlEntitiesInJson(nlohmann::json* value) {
+  if (!value) {
+    return;
+  }
+  if (value->is_string()) {
+    auto& str = value->get_ref<std::string&>();
+    str = DecodeHtmlEntities(str);
+    return;
+  }
+  if (value->is_array()) {
+    for (auto& item : *value) {
+      DecodeHtmlEntitiesInJson(&item);
+    }
+    return;
+  }
+  if (value->is_object()) {
+    for (auto& [_, item] : value->items()) {
+      DecodeHtmlEntitiesInJson(&item);
+    }
+  }
+}
+
+std::string MakeFallbackToolCallId(size_t ordinal) {
+  return "call_auto_" + std::to_string(ordinal);
+}
+
+std::string EnsureUniqueToolCallId(const std::string& preferred,
+                                   std::unordered_set<std::string>* seen_ids) {
+  if (!seen_ids) {
+    return preferred;
+  }
+  std::string candidate = preferred;
+  size_t ordinal = seen_ids->size() + 1;
+  if (!HasNonWhitespace(candidate)) {
+    candidate = MakeFallbackToolCallId(ordinal);
+  }
+  if (seen_ids->insert(candidate).second) {
+    return candidate;
+  }
+  do {
+    candidate = MakeFallbackToolCallId(ordinal++);
+  } while (!seen_ids->insert(candidate).second);
+  return candidate;
+}
+
+std::string ResolveCaseInsensitiveAllowedToolName(
+    std::string_view raw_name,
+    const std::unordered_map<std::string, std::string>& folded_allowed) {
+  auto it = folded_allowed.find(ToLower(raw_name));
+  return it != folded_allowed.end() ? it->second : std::string{};
+}
+
+std::vector<std::string> BuildStructuredToolNameCandidates(
+    std::string_view raw_name) {
+  const std::string trimmed = Trim(raw_name);
+  if (trimmed.empty()) {
+    return {};
+  }
+
+  std::vector<std::string> candidates;
+  std::unordered_set<std::string> seen;
+  auto add = [&](std::string candidate) {
+    candidate = Trim(candidate);
+    if (candidate.empty() || seen.count(candidate) > 0) {
+      return;
+    }
+    seen.insert(candidate);
+    candidates.push_back(std::move(candidate));
+  };
+
+  add(trimmed);
+  add(NormalizeToolNameToken(trimmed));
+
+  std::string normalized_delimiter = trimmed;
+  std::replace(normalized_delimiter.begin(), normalized_delimiter.end(), '/',
+               '.');
+  add(normalized_delimiter);
+  add(NormalizeToolNameToken(normalized_delimiter));
+
+  auto segments = Split(normalized_delimiter, '.');
+  std::vector<std::string> filtered;
+  for (auto& segment : segments) {
+    const auto part = Trim(segment);
+    if (!part.empty()) {
+      filtered.push_back(part);
+    }
+  }
+  if (filtered.size() > 1) {
+    for (size_t index = 1; index < filtered.size(); ++index) {
+      std::string suffix;
+      for (size_t i = index; i < filtered.size(); ++i) {
+        if (!suffix.empty()) {
+          suffix += '.';
+        }
+        suffix += filtered[i];
+      }
+      add(suffix);
+      add(NormalizeToolNameToken(suffix));
+    }
+  }
+
+  return candidates;
+}
+
+std::string ResolveStructuredAllowedToolName(
+    std::string_view raw_name,
+    const std::vector<std::string>& allowed_tool_names,
+    const std::unordered_map<std::string, std::string>& normalized_allowed,
+    const std::unordered_map<std::string, std::string>& folded_allowed) {
+  if (allowed_tool_names.empty()) {
+    return {};
+  }
+
+  for (const auto& candidate : BuildStructuredToolNameCandidates(raw_name)) {
+    if (std::find(allowed_tool_names.begin(), allowed_tool_names.end(),
+                  candidate) != allowed_tool_names.end()) {
+      return candidate;
+    }
+  }
+  for (const auto& candidate : BuildStructuredToolNameCandidates(raw_name)) {
+    auto it = normalized_allowed.find(candidate);
+    if (it != normalized_allowed.end()) {
+      return it->second;
+    }
+  }
+  for (const auto& candidate : BuildStructuredToolNameCandidates(raw_name)) {
+    auto resolved = ResolveCaseInsensitiveAllowedToolName(candidate, folded_allowed);
+    if (!resolved.empty()) {
+      return resolved;
+    }
+  }
+  return {};
+}
+
+std::string InferToolNameFromToolCallId(
+    std::string_view raw_id,
+    const std::vector<std::string>& allowed_tool_names,
+    const std::unordered_map<std::string, std::string>& normalized_allowed,
+    const std::unordered_map<std::string, std::string>& folded_allowed) {
+  const std::string id = Trim(raw_id);
+  if (id.empty() || allowed_tool_names.empty()) {
+    return {};
+  }
+
+  const std::regex trailing_index_re("[:._/-]\\d+$");
+  const std::regex trailing_digits_re("\\d+$");
+  const std::regex function_prefix_re("^functions?[._-]?", std::regex::icase);
+  const std::regex tool_prefix_re("^tools?[._-]?", std::regex::icase);
+
+  std::unordered_set<std::string> candidate_tokens;
+  auto add_token = [&](std::string token) {
+    token = Trim(token);
+    if (token.empty()) {
+      return;
+    }
+    candidate_tokens.insert(token);
+    candidate_tokens.insert(std::regex_replace(token, trailing_index_re, ""));
+    candidate_tokens.insert(std::regex_replace(token, trailing_digits_re, ""));
+
+    std::string normalized_delimiter = token;
+    std::replace(normalized_delimiter.begin(), normalized_delimiter.end(), '/',
+                 '.');
+    candidate_tokens.insert(normalized_delimiter);
+    candidate_tokens.insert(
+        std::regex_replace(normalized_delimiter, trailing_index_re, ""));
+    candidate_tokens.insert(
+        std::regex_replace(normalized_delimiter, trailing_digits_re, ""));
+
+    for (const auto& prefix_pattern : {function_prefix_re, tool_prefix_re}) {
+      auto stripped =
+          std::regex_replace(normalized_delimiter, prefix_pattern, "");
+      if (stripped != normalized_delimiter) {
+        candidate_tokens.insert(stripped);
+        candidate_tokens.insert(
+            std::regex_replace(stripped, trailing_index_re, ""));
+        candidate_tokens.insert(
+            std::regex_replace(stripped, trailing_digits_re, ""));
+      }
+    }
+  };
+
+  const auto colon = id.find(':');
+  add_token(id);
+  add_token(colon == std::string::npos ? id : id.substr(0, colon));
+
+  std::string single_match;
+  for (const auto& token : candidate_tokens) {
+    auto matched = ResolveStructuredAllowedToolName(token, allowed_tool_names,
+                                                    normalized_allowed,
+                                                    folded_allowed);
+    if (matched.empty()) {
+      continue;
+    }
+    if (!single_match.empty() && single_match != matched) {
+      return {};
+    }
+    single_match = matched;
+  }
+  return single_match;
+}
+
+bool LooksLikeMalformedToolNameCounter(std::string_view raw_name) {
+  std::string normalized = Trim(raw_name);
+  std::replace(normalized.begin(), normalized.end(), '/', '.');
+  return std::regex_search(normalized,
+                           std::regex("^(?:functions?|tools?)[._-]?",
+                                      std::regex::icase)) &&
+         std::regex_search(normalized,
+                           std::regex("(?:[:._-]\\d+|\\d+)$"));
+}
+
+std::string ResolveAllowedToolName(
+    std::string_view raw_name, const StreamNormalizationContext& context,
+    std::string_view raw_tool_call_id = {}) {
+  const std::string trimmed = Trim(raw_name);
+  if (trimmed.empty()) {
+    return InferToolNameFromToolCallId(raw_tool_call_id, context.allowed_tool_names,
+                                       context.normalized_allowed_tool_names,
+                                       context.folded_allowed_tool_names);
+  }
+  if (context.allowed_tool_names.empty()) {
+    return trimmed;
+  }
+
+  if (std::find(context.allowed_tool_names.begin(),
+                context.allowed_tool_names.end(),
+                trimmed) != context.allowed_tool_names.end()) {
+    return trimmed;
+  }
+
+  auto normalized = NormalizeToolNameToken(trimmed);
+  auto normalized_it = context.normalized_allowed_tool_names.find(normalized);
+  if (normalized_it != context.normalized_allowed_tool_names.end()) {
+    return normalized_it->second;
+  }
+
+  auto case_insensitive =
+      ResolveCaseInsensitiveAllowedToolName(trimmed,
+                                            context.folded_allowed_tool_names);
+  if (!case_insensitive.empty()) {
+    return case_insensitive;
+  }
+  case_insensitive =
+      ResolveCaseInsensitiveAllowedToolName(normalized,
+                                            context.folded_allowed_tool_names);
+  if (!case_insensitive.empty()) {
+    return case_insensitive;
+  }
+
+  auto inferred_from_name = InferToolNameFromToolCallId(
+      trimmed, context.allowed_tool_names, context.normalized_allowed_tool_names,
+      context.folded_allowed_tool_names);
+  if (!inferred_from_name.empty()) {
+    return inferred_from_name;
+  }
+
+  if (LooksLikeMalformedToolNameCounter(trimmed)) {
+    return trimmed;
+  }
+
+  auto structured = ResolveStructuredAllowedToolName(
+      trimmed, context.allowed_tool_names, context.normalized_allowed_tool_names,
+      context.folded_allowed_tool_names);
+  return structured.empty() ? trimmed : structured;
+}
+
+nlohmann::json ParseArgumentsWithRepair(std::string_view raw_arguments,
+                                       bool decode_html_entities) {
+  std::string candidate = Trim(raw_arguments);
+  if (decode_html_entities) {
+    candidate = DecodeHtmlEntities(candidate);
+  }
+  if (candidate.empty()) {
+    return nlohmann::json::object();
+  }
+
+  auto parsed = nlohmann::json::parse(candidate, nullptr, false);
+  if (!parsed.is_discarded()) {
+    if (decode_html_entities) {
+      DecodeHtmlEntitiesInJson(&parsed);
+    }
+    return parsed;
+  }
+
+  const auto start = candidate.find_first_of("{[");
+  if (start != std::string::npos) {
+    int depth = 0;
+    bool in_string = false;
+    bool escaped = false;
+    for (size_t i = start; i < candidate.size(); ++i) {
+      const char ch = candidate[i];
+      if (in_string) {
+        if (escaped) {
+          escaped = false;
+        } else if (ch == '\\') {
+          escaped = true;
+        } else if (ch == '"') {
+          in_string = false;
+        }
+        continue;
+      }
+      if (ch == '"') {
+        in_string = true;
+        continue;
+      }
+      if (ch == '{' || ch == '[') {
+        ++depth;
+      } else if (ch == '}' || ch == ']') {
+        --depth;
+        if (depth == 0) {
+          auto repaired = candidate.substr(start, i - start + 1);
+          auto repaired_json = nlohmann::json::parse(repaired, nullptr, false);
+          if (!repaired_json.is_discarded()) {
+            if (decode_html_entities) {
+              DecodeHtmlEntitiesInJson(&repaired_json);
+            }
+            return repaired_json;
+          }
+          break;
+        }
+      }
+    }
+  }
+
+  return nlohmann::json();
+}
+
+bool NormalizeToolCall(ToolCall* tool_call,
+                       const StreamNormalizationContext& context,
+                       std::unordered_set<std::string>* seen_ids,
+                       size_t ordinal) {
+  if (!tool_call) {
+    return false;
+  }
+
+  tool_call->name =
+      ResolveAllowedToolName(tool_call->name, context, tool_call->id);
+  if (!HasNonWhitespace(tool_call->name)) {
+    return false;
+  }
+  if (context.decode_html_entities) {
+    DecodeHtmlEntitiesInJson(&tool_call->arguments);
+  }
+  if (tool_call->arguments.is_null()) {
+    tool_call->arguments = nlohmann::json::object();
+  }
+  if (!tool_call->arguments.is_object() && !tool_call->arguments.is_array()) {
+    if (context.logger) {
+      context.logger->warn(
+          "Dropping malformed tool call '{}' because arguments are not structured",
+          tool_call->name);
+    }
+    return false;
+  }
+  tool_call->id = EnsureUniqueToolCallId(Trim(tool_call->id), seen_ids);
+  if (tool_call->id.empty()) {
+    tool_call->id =
+        EnsureUniqueToolCallId(MakeFallbackToolCallId(ordinal), seen_ids);
+  }
+  return true;
+}
+
+void NormalizeToolUseBlock(ContentBlock* block,
+                           const StreamNormalizationContext& context,
+                           std::unordered_set<std::string>* seen_ids,
+                           size_t ordinal) {
+  if (!block || block->type != "tool_use") {
+    return;
+  }
+  block->name = ResolveAllowedToolName(block->name, context, block->id);
+  if (context.decode_html_entities) {
+    DecodeHtmlEntitiesInJson(&block->input);
+  }
+  if (block->input.is_null()) {
+    block->input = nlohmann::json::object();
+  }
+  block->id = EnsureUniqueToolCallId(Trim(block->id), seen_ids);
+  if (block->id.empty()) {
+    block->id = EnsureUniqueToolCallId(MakeFallbackToolCallId(ordinal), seen_ids);
+  }
+}
+
+}  // namespace
+
+std::vector<std::string> ExtractAllowedToolNames(
+    const ChatCompletionRequest& request) {
+  std::vector<std::string> names;
+  names.reserve(request.tools.size());
+  for (const auto& tool : request.tools) {
+    if (!tool.is_object()) {
+      continue;
+    }
+    if (tool.value("type", "") != "function") {
+      continue;
+    }
+    if (!tool.contains("function") || !tool["function"].is_object()) {
+      continue;
+    }
+    const auto name = Trim(tool["function"].value("name", std::string{}));
+    if (!name.empty()) {
+      names.push_back(name);
+    }
+  }
+  return names;
+}
+
+StreamNormalizationContext BuildStreamNormalizationContext(
+    const std::string& provider_id, const std::string& api,
+    const ChatCompletionRequest& request,
+    const std::shared_ptr<spdlog::logger>& logger) {
+  StreamNormalizationContext context;
+  context.provider_id = provider_id;
+  context.api = api;
+  context.allowed_tool_names = ExtractAllowedToolNames(request);
+  context.logger = logger;
+
+  const auto folded_provider = ToLower(provider_id);
+  const auto folded_api = ToLower(api);
+  context.decode_html_entities = folded_provider == "xai" ||
+                                 folded_provider == "grok" ||
+                                 folded_api.find("html-entities") !=
+                                     std::string::npos;
+
+  for (const auto& name : context.allowed_tool_names) {
+    context.normalized_allowed_tool_names.emplace(NormalizeToolNameToken(name),
+                                                  name);
+    context.folded_allowed_tool_names.emplace(ToLower(name), name);
+  }
+  return context;
+}
+
+void SanitizeReplayMessages(std::vector<Message>* messages,
+                            const StreamNormalizationContext& context) {
+  if (!messages) {
+    return;
+  }
+  for (auto& message : *messages) {
+    if (message.role != "assistant") {
+      continue;
+    }
+    std::unordered_set<std::string> seen_ids;
+    std::vector<ContentBlock> sanitized;
+    size_t ordinal = 1;
+    for (auto& block : message.content) {
+      if (block.type != "tool_use") {
+        sanitized.push_back(std::move(block));
+        continue;
+      }
+      NormalizeToolUseBlock(&block, context, &seen_ids, ordinal++);
+      if (!HasNonWhitespace(block.name) ||
+          block.name.size() > kReplayToolCallNameMaxChars ||
+          block.name.find_first_of(" \t\r\n") != std::string::npos) {
+        if (context.logger) {
+          context.logger->warn("Dropping malformed replay tool call with id='{}'",
+                               block.id);
+        }
+        continue;
+      }
+      if (block.input.is_null()) {
+        continue;
+      }
+      sanitized.push_back(std::move(block));
+    }
+    message.content = std::move(sanitized);
+  }
+}
+
+void NormalizeToolCalls(std::vector<ToolCall>* tool_calls,
+                        const StreamNormalizationContext& context,
+                        std::unordered_set<std::string>* seen_ids) {
+  if (!tool_calls) {
+    return;
+  }
+  std::vector<ToolCall> normalized;
+  normalized.reserve(tool_calls->size());
+  size_t ordinal = 1;
+  for (auto& tool_call : *tool_calls) {
+    if (NormalizeToolCall(&tool_call, context, seen_ids, ordinal++)) {
+      normalized.push_back(std::move(tool_call));
+    }
+  }
+  *tool_calls = std::move(normalized);
+}
+
+std::vector<ToolCall> FinalizePendingToolCalls(
+    const std::vector<PendingToolCallFragment>& pending,
+    const StreamNormalizationContext& context,
+    std::unordered_set<std::string>* seen_ids,
+    std::vector<PendingToolCallFragment>* remaining) {
+  std::vector<ToolCall> normalized;
+  std::vector<PendingToolCallFragment> unresolved;
+  normalized.reserve(pending.size());
+
+  size_t ordinal = 1;
+  for (const auto& fragment : pending) {
+    ToolCall tool_call;
+    tool_call.id = fragment.id;
+    tool_call.name = fragment.name;
+    tool_call.arguments =
+        ParseArgumentsWithRepair(fragment.arguments, context.decode_html_entities);
+
+    if (HasNonWhitespace(fragment.arguments) && tool_call.arguments.is_null()) {
+      unresolved.push_back(fragment);
+      continue;
+    }
+    if (NormalizeToolCall(&tool_call, context, seen_ids, ordinal++)) {
+      normalized.push_back(std::move(tool_call));
+    } else if (remaining) {
+      unresolved.push_back(fragment);
+    }
+  }
+
+  if (remaining) {
+    *remaining = std::move(unresolved);
+  }
+  return normalized;
+}
+
+}  // namespace quantclaw

--- a/tests/test_agent_loop.cpp
+++ b/tests/test_agent_loop.cpp
@@ -381,6 +381,76 @@ TEST_F(AgentLoopTest, StreamReturnsNewMessages) {
   EXPECT_EQ(new_msgs.back().content[0].text, "Final answer.");
 }
 
+TEST_F(AgentLoopTest, StreamToolCallWithRecoveredNameExecutesTool) {
+  quantclaw::ChatCompletionResponse tool_chunk;
+  tool_chunk.tool_calls.push_back(
+      {"function.read:1", "read", {{"path", "/tmp/file.txt"}}});
+
+  quantclaw::ChatCompletionResponse end_chunk;
+  end_chunk.is_stream_end = true;
+
+  mock_provider_->stream_chunks = {tool_chunk, end_chunk};
+
+  std::vector<quantclaw::AgentEvent> events;
+  auto new_msgs = agent_loop_->ProcessMessageStream(
+      "Hello", {}, "System.", [&events](const quantclaw::AgentEvent& event) {
+        events.push_back(event);
+      });
+
+  ASSERT_GE(new_msgs.size(), 2u);
+  EXPECT_EQ(new_msgs[0].role, "assistant");
+  EXPECT_EQ(new_msgs[0].content[0].type, "tool_use");
+  EXPECT_EQ(new_msgs[0].content[0].name, "read");
+  EXPECT_EQ(new_msgs[1].role, "user");
+  EXPECT_EQ(new_msgs[1].content[0].type, "tool_result");
+}
+
+TEST_F(AgentLoopTest, StreamMixedValidAndInvalidToolCallsStillExecutesRecoveredTool) {
+  quantclaw::ChatCompletionResponse tool_chunk;
+  tool_chunk.tool_calls.push_back(
+      {"function.read:1", "read", {{"path", "/tmp/file.txt"}}});
+  tool_chunk.tool_calls.push_back({"call_invalid", "", {{"command", "ver"}}});
+
+  quantclaw::ChatCompletionResponse end_chunk;
+  end_chunk.is_stream_end = true;
+
+  mock_provider_->stream_chunks = {tool_chunk, end_chunk};
+
+  std::vector<quantclaw::AgentEvent> events;
+  auto new_msgs = agent_loop_->ProcessMessageStream(
+      "Hello", {}, "System.", [&events](const quantclaw::AgentEvent& event) {
+        events.push_back(event);
+      });
+
+  ASSERT_EQ(new_msgs.size(), 2u);
+  EXPECT_EQ(new_msgs[0].role, "assistant");
+  ASSERT_EQ(new_msgs[0].content.size(), 1u);
+  EXPECT_EQ(new_msgs[0].content[0].type, "tool_use");
+  EXPECT_EQ(new_msgs[0].content[0].name, "read");
+  EXPECT_EQ(new_msgs[1].role, "user");
+  ASSERT_EQ(new_msgs[1].content.size(), 1u);
+  EXPECT_EQ(new_msgs[1].content[0].type, "tool_result");
+  EXPECT_TRUE(std::none_of(new_msgs.begin(), new_msgs.end(),
+                           [](const quantclaw::Message& msg) {
+                             return msg.role == "assistant" &&
+                                    !msg.content.empty() &&
+                                    msg.content[0].type == "text" &&
+                                    msg.content[0].text ==
+                                        "I couldn't continue because the model "
+                                        "emitted an invalid tool call. Please "
+                                        "try again.";
+                           }));
+  EXPECT_TRUE(std::none_of(events.begin(), events.end(),
+                           [](const quantclaw::AgentEvent& event) {
+                             return event.type ==
+                                        quantclaw::gateway::events::kMessageEnd &&
+                                    event.data.value("content", "") ==
+                                        "I couldn't continue because the model "
+                                        "emitted an invalid tool call. Please "
+                                        "try again.";
+                           }));
+}
+
 TEST_F(AgentLoopTest, StreamInvalidToolCallReturnsReadableFallback) {
   quantclaw::ChatCompletionResponse tool_chunk;
   tool_chunk.tool_calls.push_back({"call_invalid", "", {{"command", "ver"}}});

--- a/tests/test_openai_provider.cpp
+++ b/tests/test_openai_provider.cpp
@@ -1,15 +1,21 @@
 // Copyright 2025 QuantClaw Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <atomic>
 #include <memory>
+#include <thread>
+#include <unordered_set>
 
+#include <httplib.h>
 #include <nlohmann/json.hpp>
 #include <spdlog/sinks/null_sink.h>
 #include <spdlog/spdlog.h>
 
 #include "quantclaw/providers/llm_provider.hpp"
 #include "quantclaw/providers/openai_provider.hpp"
+#include "quantclaw/providers/stream_normalization.hpp"
 
+#include "test_helpers.hpp"
 #include <gtest/gtest.h>
 
 namespace quantclaw::detail {
@@ -245,6 +251,143 @@ TEST(OpenAIProviderJsonTest, NullableStringReturnsEmptyForNull) {
   nlohmann::json j = {{"finish_reason", nullptr}};
   EXPECT_EQ(
       quantclaw::detail::json_nullable_string_or_empty(j, "finish_reason"), "");
+}
+
+TEST(OpenAIProviderNormalizationTest, FinalizePendingToolCallsRepairsNamesIdsAndArguments) {
+  auto null_sink = std::make_shared<spdlog::sinks::null_sink_mt>();
+  auto logger = std::make_shared<spdlog::logger>("normalize", null_sink);
+
+  quantclaw::ChatCompletionRequest request;
+  request.tools.push_back({{"type", "function"},
+                           {"function",
+                            {{"name", "read"},
+                             {"description", "Read file"},
+                             {"parameters",
+                              {{"type", "object"},
+                               {"properties", {{{"path", {{"type", "string"}}}}}}}}}}});
+
+  auto context = quantclaw::BuildStreamNormalizationContext(
+      "qwen", "openai-completions", request, logger);
+  std::unordered_set<std::string> seen_ids;
+  std::vector<quantclaw::PendingToolCallFragment> pending;
+  pending.push_back(quantclaw::PendingToolCallFragment{
+      0, "function.read:1", " functions.read ",
+      "prefix {\"path\":\"/tmp/a.txt\"}x"});
+  pending.push_back(
+      quantclaw::PendingToolCallFragment{1, "", "", "{\"skip\":true"});
+
+  std::vector<quantclaw::PendingToolCallFragment> remaining;
+  auto tool_calls = quantclaw::FinalizePendingToolCalls(pending, context,
+                                                        &seen_ids, &remaining);
+
+  ASSERT_EQ(tool_calls.size(), 1u);
+  EXPECT_EQ(tool_calls[0].name, "read");
+  EXPECT_EQ(tool_calls[0].id, "function.read:1");
+  EXPECT_EQ(tool_calls[0].arguments["path"], "/tmp/a.txt");
+  ASSERT_EQ(remaining.size(), 1u);
+  EXPECT_EQ(remaining[0].index, 1u);
+}
+
+TEST(OpenAIProviderNormalizationTest, NormalizeToolCallsDecodesHtmlEntitiesAndAssignsIds) {
+  auto null_sink = std::make_shared<spdlog::sinks::null_sink_mt>();
+  auto logger = std::make_shared<spdlog::logger>("normalize-html", null_sink);
+
+  quantclaw::ChatCompletionRequest request;
+  request.tools.push_back({{"type", "function"},
+                           {"function",
+                            {{"name", "write_file"},
+                             {"description", "Write file"},
+                             {"parameters",
+                              {{"type", "object"},
+                               {"properties", {{{"text", {{"type", "string"}}}}}}}}}}});
+
+  auto context = quantclaw::BuildStreamNormalizationContext(
+      "xai", "openai-completions", request, logger);
+  std::vector<quantclaw::ToolCall> tool_calls = {{"", " write-file ", {{"text", "a &amp; b"}}}};
+  std::unordered_set<std::string> seen_ids;
+
+  quantclaw::NormalizeToolCalls(&tool_calls, context, &seen_ids);
+
+  ASSERT_EQ(tool_calls.size(), 1u);
+  EXPECT_EQ(tool_calls[0].name, "write_file");
+  EXPECT_EQ(tool_calls[0].id, "call_auto_1");
+  EXPECT_EQ(tool_calls[0].arguments["text"], "a & b");
+}
+
+TEST(OpenAIProviderStreamTest, StreamingRepairsSplitToolCallAcrossChunks) {
+  const int port = quantclaw::test::FindFreePort();
+  ASSERT_GT(port, 0);
+
+  httplib::Server server;
+  std::atomic<bool> saw_request = false;
+  server.Post("/chat/completions", [&](const httplib::Request& req,
+                                        httplib::Response& res) {
+    saw_request = true;
+    auto body = nlohmann::json::parse(req.body);
+    EXPECT_EQ(body.value("model", ""), "qwen3-max");
+    EXPECT_TRUE(body.value("stream", false));
+    ASSERT_TRUE(body.contains("tools"));
+
+    res.set_chunked_content_provider(
+        "text/event-stream", [](size_t /*offset*/, httplib::DataSink& sink) {
+          const char part1[] =
+              "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"function.read:1\",\"function\":{\"name\":\" functions.read \",\"arguments\":\"prefix {\\\"path\\\":";
+          const char part2[] =
+              "\"}}]}}]}\n\n";
+          const char part3[] =
+              "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"/tmp/a.txt\\\"}x\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n";
+          const char part4[] = "data: [DONE]\n\n";
+          sink.write(part1, sizeof(part1) - 1);
+          sink.write(part2, sizeof(part2) - 1);
+          sink.write(part3, sizeof(part3) - 1);
+          sink.write(part4, sizeof(part4) - 1);
+          sink.done();
+          return true;
+        });
+  });
+
+  std::thread server_thread([&]() {
+    quantclaw::test::ReleaseHeldPort(port);
+    server.listen("127.0.0.1", port);
+  });
+  ASSERT_TRUE(quantclaw::test::WaitForServerReady(port, 5000));
+
+  auto null_sink = std::make_shared<spdlog::sinks::null_sink_mt>();
+  auto logger = std::make_shared<spdlog::logger>("openai-stream-test", null_sink);
+  quantclaw::OpenAIProvider provider(
+      "test-key", "http://127.0.0.1:" + std::to_string(port), 30, logger,
+      "qwen", "openai-completions");
+
+  quantclaw::ChatCompletionRequest request;
+  request.model = "qwen3-max";
+  request.stream = true;
+  request.messages.push_back({"user", "Read a file"});
+  request.tools.push_back({{"type", "function"},
+                           {"function",
+                            {{"name", "read"},
+                             {"description", "Read file"},
+                             {"parameters",
+                              {{"type", "object"},
+                               {"properties",
+                                {{{"path", {{"type", "string"}}}}}}}}}}});
+
+  std::vector<quantclaw::ChatCompletionResponse> chunks;
+  provider.ChatCompletionStream(
+      request, [&](const quantclaw::ChatCompletionResponse& chunk) {
+        chunks.push_back(chunk);
+      });
+
+  ASSERT_TRUE(saw_request.load());
+  ASSERT_EQ(chunks.size(), 2u);
+  EXPECT_EQ(chunks[0].finish_reason, "tool_calls");
+  ASSERT_EQ(chunks[0].tool_calls.size(), 1u);
+  EXPECT_EQ(chunks[0].tool_calls[0].id, "function.read:1");
+  EXPECT_EQ(chunks[0].tool_calls[0].name, "read");
+  EXPECT_EQ(chunks[0].tool_calls[0].arguments["path"], "/tmp/a.txt");
+  EXPECT_TRUE(chunks[1].is_stream_end);
+
+  server.stop();
+  server_thread.join();
 }
 
 TEST(OpenAIProviderJsonTest, NullableStringReturnsValueForString) {

--- a/tests/test_provider_registry.cpp
+++ b/tests/test_provider_registry.cpp
@@ -4,6 +4,8 @@
 #include <spdlog/sinks/null_sink.h>
 #include <spdlog/spdlog.h>
 
+#include "quantclaw/providers/anthropic_provider.hpp"
+#include "quantclaw/providers/openai_provider.hpp"
 #include "quantclaw/providers/provider_registry.hpp"
 
 #include <gtest/gtest.h>
@@ -140,6 +142,50 @@ TEST(ProviderRegistryTest, GetProviderCreatesInstance) {
   // Second call returns same instance
   auto provider2 = reg->GetProvider("openai");
   EXPECT_EQ(provider.get(), provider2.get());
+}
+
+TEST(ProviderRegistryTest, ProviderApiSelectsOpenAICompatibleFactory) {
+  auto reg = std::make_unique<ProviderRegistry>(make_logger("providers"));
+  reg->RegisterBuiltinFactories();
+
+  ProviderEntry entry;
+  entry.id = "qwen";
+  entry.api = "openai-completions";
+  entry.api_key = "test-key";
+  entry.base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1";
+  reg->AddProvider(entry);
+
+  auto provider = reg->GetProvider("qwen");
+  ASSERT_NE(provider, nullptr);
+  EXPECT_NE(dynamic_cast<OpenAIProvider*>(provider.get()), nullptr);
+  EXPECT_EQ(provider->GetProviderName(), "openai");
+}
+
+TEST(ProviderRegistryTest, ProviderApiSelectsOpenAICompatibleFactoryForKeyOverride) {
+  auto reg = std::make_unique<ProviderRegistry>(make_logger("providers"));
+  reg->RegisterBuiltinFactories();
+
+  ProviderEntry entry;
+  entry.id = "qwen";
+  entry.api = "openai-completions";
+  entry.base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1";
+  reg->AddProvider(entry);
+
+  auto provider = reg->GetProviderWithKey("qwen", "override-key");
+  ASSERT_NE(provider, nullptr);
+  EXPECT_NE(dynamic_cast<OpenAIProvider*>(provider.get()), nullptr);
+}
+
+TEST(ProviderRegistryTest, HasProviderUsesApiResolvedFactory) {
+  auto reg = std::make_unique<ProviderRegistry>(make_logger("providers"));
+  reg->RegisterBuiltinFactories();
+
+  ProviderEntry entry;
+  entry.id = "kimi";
+  entry.api = "anthropic-messages";
+  reg->AddProvider(entry);
+
+  EXPECT_TRUE(reg->HasProvider("kimi"));
 }
 
 TEST(ProviderRegistryTest, OpenAICodexBuiltinFactoryCreatesProvider) {


### PR DESCRIPTION
## Summary
- add OpenClaw-style streamed tool-call normalization and repair for OpenAI-compatible providers
- route provider creation by configured `api` and avoid falling back when recovered tool calls are still executable
- add regression coverage for fragmented SSE tool calls, mixed valid/invalid tool calls, and provider api dispatch

## Test plan
- [x] Build `quantclaw_tests` on Windows after the provider/agent loop refactor
- [x] Run targeted tests matching `(OpenAIProvider|AgentLoopTest|ProviderRegistryTest)` before the WSL-only adapter environment issue appeared
- [x] Build `quantclaw` in WSL and confirm the WSL binary starts the gateway
- [ ] Re-run the targeted Windows test suite after the local Device Guard restriction is cleared
- [ ] Reproduce the original qwen malformed streamed tool-call case against the new binary