### PR TITLE
fix(providers): normalize compatible tool calls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ set(QUANTCLAW_CORE_SOURCES
     src/auth/github_copilot_auth.cpp
     src/providers/curl_raii.cpp
     src/providers/openai_provider.cpp
+    src/providers/stream_normalization.cpp
     src/providers/openai_codex_provider.cpp
     src/providers/github_copilot_provider.cpp
     src/providers/anthropic_provider.cpp

--- a/include/quantclaw/providers/openai_provider.hpp
+++ b/include/quantclaw/providers/openai_provider.hpp
@@ -17,7 +17,9 @@ namespace quantclaw {
 class OpenAIProvider : public LLMProvider {
  public:
   OpenAIProvider(const std::string& api_key, const std::string& base_url,
-                 int timeout, std::shared_ptr<spdlog::logger> logger);
+                 int timeout, std::shared_ptr<spdlog::logger> logger,
+                 std::string provider_id = "openai",
+                 std::string api = "openai-completions");
 
   ChatCompletionResponse
   ChatCompletion(const ChatCompletionRequest& request) override;
@@ -39,6 +41,8 @@ class OpenAIProvider : public LLMProvider {
   std::string base_url_;
   int timeout_;
   std::shared_ptr<spdlog::logger> logger_;
+  std::string provider_id_;
+  std::string api_;
 };
 
 }  // namespace quantclaw

--- a/include/quantclaw/providers/stream_normalization.hpp
+++ b/include/quantclaw/providers/stream_normalization.hpp
@@ -36,10 +36,11 @@ struct PendingToolCallFragment {
 std::vector<std::string>
 ExtractAllowedToolNames(const ChatCompletionRequest& request);
 
-StreamNormalizationContext BuildStreamNormalizationContext(
-    const std::string& provider_id, const std::string& api,
-    const ChatCompletionRequest& request,
-    const std::shared_ptr<spdlog::logger>& logger);
+StreamNormalizationContext
+BuildStreamNormalizationContext(const std::string& provider_id,
+                                const std::string& api,
+                                const ChatCompletionRequest& request,
+                                const std::shared_ptr<spdlog::logger>& logger);
 
 void SanitizeReplayMessages(std::vector<Message>* messages,
                             const StreamNormalizationContext& context);

--- a/include/quantclaw/providers/stream_normalization.hpp
+++ b/include/quantclaw/providers/stream_normalization.hpp
@@ -1,0 +1,57 @@
+// Copyright 2025 QuantClaw Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+#include <spdlog/spdlog.h>
+
+#include "quantclaw/providers/llm_provider.hpp"
+
+namespace quantclaw {
+
+struct StreamNormalizationContext {
+  std::string provider_id;
+  std::string api;
+  std::vector<std::string> allowed_tool_names;
+  std::unordered_map<std::string, std::string> normalized_allowed_tool_names;
+  std::unordered_map<std::string, std::string> folded_allowed_tool_names;
+  bool decode_html_entities = false;
+  std::shared_ptr<spdlog::logger> logger;
+};
+
+struct PendingToolCallFragment {
+  size_t index = 0;
+  std::string id;
+  std::string name;
+  std::string arguments;
+};
+
+std::vector<std::string>
+ExtractAllowedToolNames(const ChatCompletionRequest& request);
+
+StreamNormalizationContext BuildStreamNormalizationContext(
+    const std::string& provider_id, const std::string& api,
+    const ChatCompletionRequest& request,
+    const std::shared_ptr<spdlog::logger>& logger);
+
+void SanitizeReplayMessages(std::vector<Message>* messages,
+                            const StreamNormalizationContext& context);
+
+void NormalizeToolCalls(std::vector<ToolCall>* tool_calls,
+                        const StreamNormalizationContext& context,
+                        std::unordered_set<std::string>* seen_ids = nullptr);
+
+std::vector<ToolCall> FinalizePendingToolCalls(
+    const std::vector<PendingToolCallFragment>& pending,
+    const StreamNormalizationContext& context,
+    std::unordered_set<std::string>* seen_ids = nullptr,
+    std::vector<PendingToolCallFragment>* remaining = nullptr);
+
+}  // namespace quantclaw

--- a/src/providers/openai_provider.cpp
+++ b/src/providers/openai_provider.cpp
@@ -8,12 +8,14 @@
 #include <fstream>
 #include <sstream>
 #include <string_view>
+#include <unordered_set>
 
 #include <curl/curl.h>
 #include <nlohmann/json.hpp>
 #include <spdlog/spdlog.h>
 
 #include "quantclaw/providers/provider_error.hpp"
+#include "quantclaw/providers/stream_normalization.hpp"
 
 namespace quantclaw {
 
@@ -217,11 +219,14 @@ std::string SummarizeErrorBodyForLog(std::string_view body) {
 
 OpenAIProvider::OpenAIProvider(const std::string& api_key,
                                const std::string& base_url, int timeout,
-                               std::shared_ptr<spdlog::logger> logger)
+                               std::shared_ptr<spdlog::logger> logger,
+                               std::string provider_id, std::string api)
     : api_key_(api_key),
       base_url_(base_url),
       timeout_(timeout),
-      logger_(logger) {
+      logger_(logger),
+      provider_id_(std::move(provider_id)),
+      api_(std::move(api)) {
   if (base_url_.empty()) {
     base_url_ = "https://api.openai.com/v1";
   }
@@ -238,11 +243,16 @@ std::string OpenAIProvider::ResolveBaseUrl() const {
 }
 
 std::string OpenAIProvider::ProviderId() const {
-  return "openai";
+  return provider_id_;
 }
 
 ChatCompletionResponse
 OpenAIProvider::ChatCompletion(const ChatCompletionRequest& request) {
+  auto normalized_messages = request.messages;
+  const auto normalization_context =
+      BuildStreamNormalizationContext(ProviderId(), api_, request, logger_);
+  SanitizeReplayMessages(&normalized_messages, normalization_context);
+
   // Build JSON payload
   nlohmann::json payload;
   payload["model"] = request.model;
@@ -251,7 +261,7 @@ OpenAIProvider::ChatCompletion(const ChatCompletionRequest& request) {
 
   // Add messages
   payload["messages"] =
-      serialize_messages_to_openai(request.messages, request.thinking != "off");
+      serialize_messages_to_openai(normalized_messages, request.thinking != "off");
 
   // Add tools if provided
   if (!request.tools.empty()) {
@@ -289,12 +299,17 @@ OpenAIProvider::ChatCompletion(const ChatCompletionRequest& request) {
           if (tc.contains("function")) {
             tool_call.name = tc["function"].value("name", "");
             if (tc["function"].contains("arguments")) {
-              auto args_str = tc["function"]["arguments"].get<std::string>();
-              tool_call.arguments = nlohmann::json::parse(args_str);
+              const auto& args = tc["function"]["arguments"];
+              if (args.is_string()) {
+                tool_call.arguments = args.get<std::string>();
+              } else {
+                tool_call.arguments = args;
+              }
             }
           }
-          result.tool_calls.push_back(tool_call);
+          result.tool_calls.push_back(std::move(tool_call));
         }
+        NormalizeToolCalls(&result.tool_calls, normalization_context);
       }
     }
     if (choice.contains("finish_reason")) {
@@ -389,56 +404,32 @@ struct StreamContext {
   std::string buffer;  // incomplete line across chunks
   std::string raw_response_body;
   std::shared_ptr<spdlog::logger> logger;
-
-  // Accumulated tool calls (SSE delivers them in fragments)
-  struct PendingToolCall {
-    std::string id;
-    std::string name;
-    std::string arguments;
-  };
-  std::vector<PendingToolCall> pending_tool_calls;
+  StreamNormalizationContext normalization_context;
+  std::unordered_set<std::string> seen_tool_call_ids;
+  std::vector<PendingToolCallFragment> pending_tool_calls;
 };
 
-static bool HasNonWhitespace(const std::string& value) {
-  return std::any_of(value.begin(), value.end(),
-                     [](unsigned char ch) { return !std::isspace(ch); });
-}
-
 static std::vector<ToolCall> TakeCompleteToolCalls(StreamContext* ctx,
-                                                   bool drop_incomplete) {
-  std::vector<ToolCall> complete;
-  std::vector<StreamContext::PendingToolCall> remaining;
+                                                   bool keep_incomplete) {
+  std::vector<PendingToolCallFragment> remaining;
+  auto complete = FinalizePendingToolCalls(ctx->pending_tool_calls,
+                                           ctx->normalization_context,
+                                           &ctx->seen_tool_call_ids,
+                                           &remaining);
 
-  for (const auto& pending : ctx->pending_tool_calls) {
-    nlohmann::json parsed_arguments = nlohmann::json::object();
-    bool invalid_arguments = false;
-    if (HasNonWhitespace(pending.arguments)) {
-      parsed_arguments =
-          nlohmann::json::parse(pending.arguments, nullptr, false);
-      invalid_arguments = parsed_arguments.is_discarded();
-    }
-
-    if (pending.id.empty() || !HasNonWhitespace(pending.name) ||
-        invalid_arguments) {
-      if (!drop_incomplete) {
-        remaining.push_back(pending);
-      } else if (ctx->logger) {
+  if (!keep_incomplete) {
+    for (const auto& pending : remaining) {
+      if (ctx->logger) {
         ctx->logger->warn(
-            "Dropping incomplete streamed tool call: id='{}', name='{}', "
-            "arguments_len={}",
+            "Dropping incomplete streamed tool call: id='{}', name='{}', arguments_len={}",
             pending.id, pending.name, pending.arguments.size());
       }
-      continue;
     }
-
-    ToolCall tc;
-    tc.id = pending.id;
-    tc.name = pending.name;
-    tc.arguments = std::move(parsed_arguments);
-    complete.push_back(std::move(tc));
+    ctx->pending_tool_calls.clear();
+    return complete;
   }
 
-  ctx->pending_tool_calls = std::move(remaining);
+  ctx->pending_tool_calls = remaining;
   return complete;
 }
 
@@ -470,7 +461,7 @@ static size_t StreamWriteCallback(void* contents, size_t size, size_t nmemb,
     if (data == "[DONE]") {
       // Emit any accumulated tool calls before stream end
       if (!ctx->pending_tool_calls.empty()) {
-        auto complete = TakeCompleteToolCalls(ctx, true);
+        auto complete = TakeCompleteToolCalls(ctx, false);
         ChatCompletionResponse tc_resp;
         tc_resp.finish_reason = "tool_calls";
         tc_resp.tool_calls = std::move(complete);
@@ -546,6 +537,7 @@ static size_t StreamWriteCallback(void* contents, size_t size, size_t nmemb,
         }
 
         auto& ptc = ctx->pending_tool_calls[tool_index];
+        ptc.index = tool_index;
         if (tc_delta.contains("id") && !tc_delta["id"].is_null()) {
           ptc.id = tc_delta["id"].get<std::string>();
         }
@@ -563,7 +555,7 @@ static size_t StreamWriteCallback(void* contents, size_t size, size_t nmemb,
 
     // If finish_reason is "tool_calls", emit accumulated tool calls now
     if (finish_reason == "tool_calls" && !ctx->pending_tool_calls.empty()) {
-      auto complete = TakeCompleteToolCalls(ctx, false);
+      auto complete = TakeCompleteToolCalls(ctx, true);
       ChatCompletionResponse tc_resp;
       tc_resp.finish_reason = "tool_calls";
       tc_resp.tool_calls = std::move(complete);
@@ -579,6 +571,11 @@ static size_t StreamWriteCallback(void* contents, size_t size, size_t nmemb,
 void OpenAIProvider::ChatCompletionStream(
     const ChatCompletionRequest& request,
     std::function<void(const ChatCompletionResponse&)> callback) {
+  auto normalized_messages = request.messages;
+  const auto normalization_context =
+      BuildStreamNormalizationContext(ProviderId(), api_, request, logger_);
+  SanitizeReplayMessages(&normalized_messages, normalization_context);
+
   // Build JSON payload with stream=true
   nlohmann::json payload;
   payload["model"] = request.model;
@@ -587,7 +584,7 @@ void OpenAIProvider::ChatCompletionStream(
   payload["stream"] = true;
 
   payload["messages"] =
-      serialize_messages_to_openai(request.messages, request.thinking != "off");
+      serialize_messages_to_openai(normalized_messages, request.thinking != "off");
 
   if (!request.tools.empty()) {
     payload["tools"] = request.tools;
@@ -602,6 +599,7 @@ void OpenAIProvider::ChatCompletionStream(
   StreamContext stream_ctx;
   stream_ctx.callback = callback;
   stream_ctx.logger = logger_;
+  stream_ctx.normalization_context = normalization_context;
 
   RetryAfterCapture retry_capture;
 

--- a/src/providers/openai_provider.cpp
+++ b/src/providers/openai_provider.cpp
@@ -260,8 +260,8 @@ OpenAIProvider::ChatCompletion(const ChatCompletionRequest& request) {
   payload["max_tokens"] = request.max_tokens;
 
   // Add messages
-  payload["messages"] =
-      serialize_messages_to_openai(normalized_messages, request.thinking != "off");
+  payload["messages"] = serialize_messages_to_openai(normalized_messages,
+                                                     request.thinking != "off");
 
   // Add tools if provided
   if (!request.tools.empty()) {
@@ -412,16 +412,16 @@ struct StreamContext {
 static std::vector<ToolCall> TakeCompleteToolCalls(StreamContext* ctx,
                                                    bool keep_incomplete) {
   std::vector<PendingToolCallFragment> remaining;
-  auto complete = FinalizePendingToolCalls(ctx->pending_tool_calls,
-                                           ctx->normalization_context,
-                                           &ctx->seen_tool_call_ids,
-                                           &remaining);
+  auto complete = FinalizePendingToolCalls(
+      ctx->pending_tool_calls, ctx->normalization_context,
+      &ctx->seen_tool_call_ids, &remaining);
 
   if (!keep_incomplete) {
     for (const auto& pending : remaining) {
       if (ctx->logger) {
         ctx->logger->warn(
-            "Dropping incomplete streamed tool call: id='{}', name='{}', arguments_len={}",
+            "Dropping incomplete streamed tool call: id='{}', name='{}', "
+            "arguments_len={}",
             pending.id, pending.name, pending.arguments.size());
       }
     }
@@ -583,8 +583,8 @@ void OpenAIProvider::ChatCompletionStream(
   payload["max_tokens"] = request.max_tokens;
   payload["stream"] = true;
 
-  payload["messages"] =
-      serialize_messages_to_openai(normalized_messages, request.thinking != "off");
+  payload["messages"] = serialize_messages_to_openai(normalized_messages,
+                                                     request.thinking != "off");
 
   if (!request.tools.empty()) {
     payload["tools"] = request.tools;

--- a/src/providers/provider_registry.cpp
+++ b/src/providers/provider_registry.cpp
@@ -46,11 +46,11 @@ std::string ResolveFactoryIdForEntry(const ProviderEntry& entry) {
 std::shared_ptr<LLMProvider> CreateOpenAICompatibleProvider(
     const ProviderEntry& entry, std::shared_ptr<spdlog::logger> logger,
     std::string_view default_base_url, std::string_view default_api) {
-  std::string url = entry.base_url.empty() ? std::string(default_base_url)
-                                           : entry.base_url;
-  return std::make_shared<OpenAIProvider>(entry.api_key, url, entry.timeout,
-                                          std::move(logger), entry.id,
-                                          NormalizeProviderApi(entry, default_api));
+  std::string url =
+      entry.base_url.empty() ? std::string(default_base_url) : entry.base_url;
+  return std::make_shared<OpenAIProvider>(
+      entry.api_key, url, entry.timeout, std::move(logger), entry.id,
+      NormalizeProviderApi(entry, default_api));
 }
 
 }  // namespace

--- a/src/providers/provider_registry.cpp
+++ b/src/providers/provider_registry.cpp
@@ -4,6 +4,7 @@
 #include "quantclaw/providers/provider_registry.hpp"
 
 #include <algorithm>
+#include <string_view>
 
 #include "quantclaw/auth/github_copilot_auth.hpp"
 #include "quantclaw/auth/openai_codex_auth.hpp"
@@ -13,6 +14,47 @@
 #include "quantclaw/providers/openai_provider.hpp"
 
 namespace quantclaw {
+namespace {
+
+std::string NormalizeProviderApi(const ProviderEntry& entry,
+                                 std::string_view fallback_api) {
+  if (!entry.api.empty()) {
+    return entry.api;
+  }
+  return std::string(fallback_api);
+}
+
+std::string ResolveFactoryIdForEntry(const ProviderEntry& entry) {
+  if (!entry.api.empty()) {
+    if (entry.api == "anthropic-messages") {
+      return "anthropic";
+    }
+    if (entry.api == "google-generative-ai") {
+      return "gemini";
+    }
+    if (entry.api == "openai-codex-responses") {
+      return "openai-codex";
+    }
+    if (entry.api == "openai-completions" || entry.api == "openai-responses" ||
+        entry.api == "azure-openai-responses") {
+      return "openai";
+    }
+  }
+  return entry.id;
+}
+
+std::shared_ptr<LLMProvider> CreateOpenAICompatibleProvider(
+    const ProviderEntry& entry, std::shared_ptr<spdlog::logger> logger,
+    std::string_view default_base_url, std::string_view default_api) {
+  std::string url = entry.base_url.empty() ? std::string(default_base_url)
+                                           : entry.base_url;
+  return std::make_shared<OpenAIProvider>(entry.api_key, url, entry.timeout,
+                                          std::move(logger), entry.id,
+                                          NormalizeProviderApi(entry, default_api));
+}
+
+}  // namespace
+
 // --- ModelRef ---
 
 ModelRef ModelRef::parse(const std::string& raw,
@@ -43,10 +85,9 @@ void ProviderRegistry::RegisterBuiltinFactories() {
   // OpenAI-compatible factory (also works for Ollama, Together, etc.)
   RegisterFactory("openai", [](const ProviderEntry& entry,
                                std::shared_ptr<spdlog::logger> logger) {
-    std::string url =
-        entry.base_url.empty() ? "https://api.openai.com/v1" : entry.base_url;
-    return std::make_shared<OpenAIProvider>(entry.api_key, url, entry.timeout,
-                                            logger);
+    return CreateOpenAICompatibleProvider(entry, std::move(logger),
+                                          "https://api.openai.com/v1",
+                                          "openai-completions");
   });
 
   RegisterFactory("openai-codex", [](const ProviderEntry& entry,
@@ -87,21 +128,18 @@ void ProviderRegistry::RegisterBuiltinFactories() {
   // Ollama (uses OpenAI-compatible API)
   RegisterFactory("ollama", [](const ProviderEntry& entry,
                                std::shared_ptr<spdlog::logger> logger) {
-    std::string url =
-        entry.base_url.empty() ? "http://localhost:11434/v1" : entry.base_url;
-    return std::make_shared<OpenAIProvider>(entry.api_key, url, entry.timeout,
-                                            logger);
+    return CreateOpenAICompatibleProvider(entry, std::move(logger),
+                                          "http://localhost:11434/v1",
+                                          "openai-completions");
   });
 
   // Gemini / Google (uses OpenAI-compatible API via base_url override)
   RegisterFactory("gemini", [](const ProviderEntry& entry,
                                std::shared_ptr<spdlog::logger> logger) {
-    std::string url =
-        entry.base_url.empty()
-            ? "https://generativelanguage.googleapis.com/v1beta/openai"
-            : entry.base_url;
-    return std::make_shared<OpenAIProvider>(entry.api_key, url, entry.timeout,
-                                            logger);
+    return CreateOpenAICompatibleProvider(
+        entry, std::move(logger),
+        "https://generativelanguage.googleapis.com/v1beta/openai",
+        "google-generative-ai");
   });
 
   // Google alias
@@ -110,28 +148,25 @@ void ProviderRegistry::RegisterBuiltinFactories() {
   // Bedrock (uses OpenAI-compatible gateway)
   RegisterFactory("bedrock", [](const ProviderEntry& entry,
                                 std::shared_ptr<spdlog::logger> logger) {
-    std::string url =
-        entry.base_url.empty() ? "http://localhost:8080/v1" : entry.base_url;
-    return std::make_shared<OpenAIProvider>(entry.api_key, url, entry.timeout,
-                                            logger);
+    return CreateOpenAICompatibleProvider(entry, std::move(logger),
+                                          "http://localhost:8080/v1",
+                                          "openai-completions");
   });
 
   // OpenRouter
   RegisterFactory("openrouter", [](const ProviderEntry& entry,
                                    std::shared_ptr<spdlog::logger> logger) {
-    std::string url = entry.base_url.empty() ? "https://openrouter.ai/api/v1"
-                                             : entry.base_url;
-    return std::make_shared<OpenAIProvider>(entry.api_key, url, entry.timeout,
-                                            logger);
+    return CreateOpenAICompatibleProvider(entry, std::move(logger),
+                                          "https://openrouter.ai/api/v1",
+                                          "openai-completions");
   });
 
   // Together
   RegisterFactory("together", [](const ProviderEntry& entry,
                                  std::shared_ptr<spdlog::logger> logger) {
-    std::string url =
-        entry.base_url.empty() ? "https://api.together.xyz/v1" : entry.base_url;
-    return std::make_shared<OpenAIProvider>(entry.api_key, url, entry.timeout,
-                                            logger);
+    return CreateOpenAICompatibleProvider(entry, std::move(logger),
+                                          "https://api.together.xyz/v1",
+                                          "openai-completions");
   });
 }
 
@@ -164,6 +199,7 @@ void ProviderRegistry::LoadFromConfig(const nlohmann::json& providers_json) {
     if (entry.api_key_env.empty()) {
       entry.api_key_env = val.value("api_key_env", std::string{});
     }
+    entry.api = val.value("api", std::string{});
     entry.timeout = val.value("timeout", 30);
     if (val.contains("extra")) {
       entry.extra = val["extra"];
@@ -210,13 +246,6 @@ ProviderRegistry::GetProvider(const std::string& provider_id) {
   if (it != instances_.end())
     return it->second;
 
-  // Find factory
-  auto fit = factories_.find(provider_id);
-  if (fit == factories_.end()) {
-    logger_->error("No factory registered for provider: {}", provider_id);
-    return nullptr;
-  }
-
   // Find entry
   auto eit = entries_.find(provider_id);
   if (eit == entries_.end()) {
@@ -226,6 +255,15 @@ ProviderRegistry::GetProvider(const std::string& provider_id) {
     entry.api_key = resolve_api_key(entry);
     entries_[provider_id] = entry;
     eit = entries_.find(provider_id);
+  }
+
+  auto factory_id = ResolveFactoryIdForEntry(eit->second);
+  auto fit = factories_.find(factory_id);
+  if (fit == factories_.end()) {
+    logger_->error(
+        "No factory registered for provider: {} (resolved from {} with api={})",
+        factory_id, provider_id, eit->second.api);
+    return nullptr;
   }
 
   auto provider = fit->second(eit->second, logger_);
@@ -241,12 +279,6 @@ ProviderRegistry::GetProviderForModel(const ModelRef& ref) {
 std::shared_ptr<LLMProvider>
 ProviderRegistry::GetProviderWithKey(const std::string& provider_id,
                                      const std::string& api_key) {
-  auto fit = factories_.find(provider_id);
-  if (fit == factories_.end()) {
-    logger_->error("No factory for provider: {}", provider_id);
-    return nullptr;
-  }
-
   // Build a temporary entry with the given API key
   ProviderEntry entry;
   auto eit = entries_.find(provider_id);
@@ -256,6 +288,14 @@ ProviderRegistry::GetProviderWithKey(const std::string& provider_id,
     entry.id = provider_id;
   }
   entry.api_key = api_key;
+
+  auto factory_id = ResolveFactoryIdForEntry(entry);
+  auto fit = factories_.find(factory_id);
+  if (fit == factories_.end()) {
+    logger_->error("No factory for provider: {} (resolved from {} with api={})",
+                   factory_id, provider_id, entry.api);
+    return nullptr;
+  }
 
   return fit->second(entry, logger_);
 }
@@ -278,7 +318,11 @@ std::vector<ModelAlias> ProviderRegistry::Aliases() const {
 }
 
 bool ProviderRegistry::HasProvider(const std::string& provider_id) const {
-  return factories_.count(provider_id) > 0 || entries_.count(provider_id) > 0;
+  if (entries_.count(provider_id) > 0) {
+    const auto& entry = entries_.at(provider_id);
+    return factories_.count(ResolveFactoryIdForEntry(entry)) > 0;
+  }
+  return factories_.count(provider_id) > 0;
 }
 
 const ProviderEntry*

--- a/src/providers/stream_normalization.cpp
+++ b/src/providers/stream_normalization.cpp
@@ -102,24 +102,28 @@ std::optional<std::string> DecodeHtmlEntity(std::string_view entity) {
 std::string DecodeHtmlEntities(std::string_view raw) {
   std::string decoded;
   decoded.reserve(raw.size());
-  for (size_t i = 0; i < raw.size(); ++i) {
+  size_t i = 0;
+  while (i < raw.size()) {
     if (raw[i] != '&') {
       decoded.push_back(raw[i]);
+      ++i;
       continue;
     }
     const auto semi = raw.find(';', i + 1);
     if (semi == std::string_view::npos) {
       decoded.push_back(raw[i]);
+      ++i;
       continue;
     }
     const auto entity = raw.substr(i + 1, semi - i - 1);
     auto replacement = DecodeHtmlEntity(entity);
     if (!replacement) {
       decoded.push_back(raw[i]);
+      ++i;
       continue;
     }
     decoded += *replacement;
-    i = semi;
+    i = semi + 1;
   }
   return decoded;
 }
@@ -336,7 +340,7 @@ bool LooksLikeMalformedToolNameCounter(std::string_view raw_name) {
 std::string ResolveAllowedToolName(std::string_view raw_name,
                                    const StreamNormalizationContext& context,
                                    std::string_view raw_tool_call_id = {}) {
-  const std::string trimmed = Trim(raw_name);
+  std::string trimmed = Trim(raw_name);
   if (trimmed.empty()) {
     return InferToolNameFromToolCallId(raw_tool_call_id,
                                        context.allowed_tool_names,

--- a/src/providers/stream_normalization.cpp
+++ b/src/providers/stream_normalization.cpp
@@ -20,9 +20,8 @@ namespace {
 constexpr size_t kReplayToolCallNameMaxChars = 64;
 
 bool HasNonWhitespace(std::string_view value) {
-  return std::any_of(value.begin(), value.end(), [](unsigned char ch) {
-    return !std::isspace(ch);
-  });
+  return std::any_of(value.begin(), value.end(),
+                     [](unsigned char ch) { return !std::isspace(ch); });
 }
 
 std::string NormalizeToolNameToken(std::string_view raw) {
@@ -50,12 +49,9 @@ std::string NormalizeToolNameToken(std::string_view raw) {
 
 const std::unordered_map<std::string, std::string>& HtmlEntityMap() {
   static const auto* entities =
-      new std::unordered_map<std::string, std::string>{{"amp", "&"},
-                                                       {"quot", "\""},
-                                                       {"apos", "'"},
-                                                       {"#39", "'"},
-                                                       {"lt", "<"},
-                                                       {"gt", ">"}};  // NOLINT
+      new std::unordered_map<std::string, std::string>{
+          {"amp", "&"}, {"quot", "\""}, {"apos", "'"},
+          {"#39", "'"}, {"lt", "<"},    {"gt", ">"}};  // NOLINT
   return *entities;
 }
 
@@ -179,8 +175,8 @@ std::string ResolveCaseInsensitiveAllowedToolName(
   return it != folded_allowed.end() ? it->second : std::string{};
 }
 
-std::vector<std::string> BuildStructuredToolNameCandidates(
-    std::string_view raw_name) {
+std::vector<std::string>
+BuildStructuredToolNameCandidates(std::string_view raw_name) {
   const std::string trimmed = Trim(raw_name);
   if (trimmed.empty()) {
     return {};
@@ -330,16 +326,15 @@ std::string InferToolNameFromToolCallId(
 bool LooksLikeMalformedToolNameCounter(std::string_view raw_name) {
   std::string normalized = Trim(raw_name);
   std::replace(normalized.begin(), normalized.end(), '/', '.');
-  return std::regex_search(normalized,
-                           std::regex("^(?:functions?|tools?)[._-]?",
-                                      std::regex::icase)) &&
-         std::regex_search(normalized,
-                           std::regex("(?:[:._-]\\d+|\\d+)$"));
+  return std::regex_search(
+             normalized,
+             std::regex("^(?:functions?|tools?)[._-]?", std::regex::icase)) &&
+         std::regex_search(normalized, std::regex("(?:[:._-]\\d+|\\d+)$"));
 }
 
-std::string ResolveAllowedToolName(
-    std::string_view raw_name, const StreamNormalizationContext& context,
-    std::string_view raw_tool_call_id = {}) {
+std::string ResolveAllowedToolName(std::string_view raw_name,
+                                   const StreamNormalizationContext& context,
+                                   std::string_view raw_tool_call_id = {}) {
   const std::string trimmed = Trim(raw_name);
   if (trimmed.empty()) {
     return InferToolNameFromToolCallId(raw_tool_call_id,
@@ -375,8 +370,8 @@ std::string ResolveAllowedToolName(
   }
 
   auto inferred_from_name = InferToolNameFromToolCallId(
-      trimmed, context.allowed_tool_names, context.normalized_allowed_tool_names,
-      context.folded_allowed_tool_names);
+      trimmed, context.allowed_tool_names,
+      context.normalized_allowed_tool_names, context.folded_allowed_tool_names);
   if (!inferred_from_name.empty()) {
     return inferred_from_name;
   }
@@ -386,13 +381,13 @@ std::string ResolveAllowedToolName(
   }
 
   auto structured = ResolveStructuredAllowedToolName(
-      trimmed, context.allowed_tool_names, context.normalized_allowed_tool_names,
-      context.folded_allowed_tool_names);
+      trimmed, context.allowed_tool_names,
+      context.normalized_allowed_tool_names, context.folded_allowed_tool_names);
   return structured.empty() ? trimmed : structured;
 }
 
 nlohmann::json ParseArgumentsWithRepair(std::string_view raw_arguments,
-                                       bool decode_html_entities) {
+                                        bool decode_html_entities) {
   std::string candidate = Trim(raw_arguments);
   if (decode_html_entities) {
     candidate = DecodeHtmlEntities(candidate);
@@ -479,7 +474,8 @@ bool NormalizeToolCall(ToolCall* tool_call,
   if (!tool_call->arguments.is_object() && !tool_call->arguments.is_array()) {
     if (context.logger) {
       context.logger->warn(
-          "Dropping malformed tool call '{}' because arguments are not structured",
+          "Dropping malformed tool call '{}' because arguments are not "
+          "structured",
           tool_call->name);
     }
     return false;
@@ -515,8 +511,8 @@ void NormalizeToolUseBlock(ContentBlock* block,
 
 }  // namespace
 
-std::vector<std::string> ExtractAllowedToolNames(
-    const ChatCompletionRequest& request) {
+std::vector<std::string>
+ExtractAllowedToolNames(const ChatCompletionRequest& request) {
   std::vector<std::string> names;
   names.reserve(request.tools.size());
   for (const auto& tool : request.tools) {
@@ -537,10 +533,11 @@ std::vector<std::string> ExtractAllowedToolNames(
   return names;
 }
 
-StreamNormalizationContext BuildStreamNormalizationContext(
-    const std::string& provider_id, const std::string& api,
-    const ChatCompletionRequest& request,
-    const std::shared_ptr<spdlog::logger>& logger) {
+StreamNormalizationContext
+BuildStreamNormalizationContext(const std::string& provider_id,
+                                const std::string& api,
+                                const ChatCompletionRequest& request,
+                                const std::shared_ptr<spdlog::logger>& logger) {
   StreamNormalizationContext context;
   context.provider_id = provider_id;
   context.api = api;
@@ -549,10 +546,9 @@ StreamNormalizationContext BuildStreamNormalizationContext(
 
   const auto folded_provider = ToLower(provider_id);
   const auto folded_api = ToLower(api);
-  context.decode_html_entities = folded_provider == "xai" ||
-                                 folded_provider == "grok" ||
-                                 folded_api.find("html-entities") !=
-                                     std::string::npos;
+  context.decode_html_entities =
+      folded_provider == "xai" || folded_provider == "grok" ||
+      folded_api.find("html-entities") != std::string::npos;
 
   for (const auto& name : context.allowed_tool_names) {
     context.normalized_allowed_tool_names.emplace(NormalizeToolNameToken(name),
@@ -615,11 +611,11 @@ void NormalizeToolCalls(std::vector<ToolCall>* tool_calls,
   *tool_calls = std::move(normalized);
 }
 
-std::vector<ToolCall> FinalizePendingToolCalls(
-    const std::vector<PendingToolCallFragment>& pending,
-    const StreamNormalizationContext& context,
-    std::unordered_set<std::string>* seen_ids,
-    std::vector<PendingToolCallFragment>* remaining) {
+std::vector<ToolCall>
+FinalizePendingToolCalls(const std::vector<PendingToolCallFragment>& pending,
+                         const StreamNormalizationContext& context,
+                         std::unordered_set<std::string>* seen_ids,
+                         std::vector<PendingToolCallFragment>* remaining) {
   std::vector<ToolCall> normalized;
   std::vector<PendingToolCallFragment> unresolved;
   normalized.reserve(pending.size());
@@ -629,8 +625,8 @@ std::vector<ToolCall> FinalizePendingToolCalls(
     ToolCall tool_call;
     tool_call.id = fragment.id;
     tool_call.name = fragment.name;
-    tool_call.arguments =
-        ParseArgumentsWithRepair(fragment.arguments, context.decode_html_entities);
+    tool_call.arguments = ParseArgumentsWithRepair(
+        fragment.arguments, context.decode_html_entities);
 
     if (HasNonWhitespace(fragment.arguments) && tool_call.arguments.is_null()) {
       unresolved.push_back(fragment);

--- a/src/providers/stream_normalization.cpp
+++ b/src/providers/stream_normalization.cpp
@@ -28,7 +28,8 @@ std::string NormalizeToolNameToken(std::string_view raw) {
   std::string normalized;
   normalized.reserve(raw.size());
   bool last_was_separator = false;
-  for (unsigned char ch : raw) {
+  for (char raw_ch : raw) {
+    const auto ch = static_cast<unsigned char>(raw_ch);
     if (std::isalnum(ch)) {
       normalized.push_back(static_cast<char>(std::tolower(ch)));
       last_was_separator = false;

--- a/src/providers/stream_normalization.cpp
+++ b/src/providers/stream_normalization.cpp
@@ -1,0 +1,652 @@
+// Copyright 2025 QuantClaw Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "quantclaw/providers/stream_normalization.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <optional>
+#include <regex>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+
+#include "quantclaw/common/string_util.hpp"
+#include "quantclaw/core/content_block.hpp"
+
+namespace quantclaw {
+namespace {
+
+constexpr size_t kReplayToolCallNameMaxChars = 64;
+
+bool HasNonWhitespace(std::string_view value) {
+  return std::any_of(value.begin(), value.end(), [](unsigned char ch) {
+    return !std::isspace(ch);
+  });
+}
+
+std::string NormalizeToolNameToken(std::string_view raw) {
+  std::string normalized;
+  normalized.reserve(raw.size());
+  bool last_was_separator = false;
+  for (unsigned char ch : raw) {
+    if (std::isalnum(ch)) {
+      normalized.push_back(static_cast<char>(std::tolower(ch)));
+      last_was_separator = false;
+      continue;
+    }
+    if (ch == '.' || ch == '_' || ch == '-' || ch == '/') {
+      if (!last_was_separator && !normalized.empty()) {
+        normalized.push_back('.');
+      }
+      last_was_separator = true;
+    }
+  }
+  while (!normalized.empty() && normalized.back() == '.') {
+    normalized.pop_back();
+  }
+  return normalized;
+}
+
+const std::unordered_map<std::string, std::string>& HtmlEntityMap() {
+  static const auto* entities =
+      new std::unordered_map<std::string, std::string>{{"amp", "&"},
+                                                       {"quot", "\""},
+                                                       {"apos", "'"},
+                                                       {"#39", "'"},
+                                                       {"lt", "<"},
+                                                       {"gt", ">"}};  // NOLINT
+  return *entities;
+}
+
+std::optional<std::string> DecodeHtmlEntity(std::string_view entity) {
+  const auto& entities = HtmlEntityMap();
+  auto it = entities.find(std::string(entity));
+  if (it != entities.end()) {
+    return it->second;
+  }
+
+  if (entity.size() >= 2 && entity[0] == '#') {
+    int codepoint = -1;
+    try {
+      if (entity[1] == 'x' || entity[1] == 'X') {
+        codepoint = std::stoi(std::string(entity.substr(2)), nullptr, 16);
+      } else {
+        codepoint = std::stoi(std::string(entity.substr(1)), nullptr, 10);
+      }
+    } catch (...) {
+      return std::nullopt;
+    }
+    if (codepoint < 0 || codepoint > 0x10FFFF) {
+      return std::nullopt;
+    }
+    std::string decoded;
+    if (codepoint <= 0x7F) {
+      decoded.push_back(static_cast<char>(codepoint));
+    } else if (codepoint <= 0x7FF) {
+      decoded.push_back(static_cast<char>(0xC0 | ((codepoint >> 6) & 0x1F)));
+      decoded.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+    } else if (codepoint <= 0xFFFF) {
+      decoded.push_back(static_cast<char>(0xE0 | ((codepoint >> 12) & 0x0F)));
+      decoded.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
+      decoded.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+    } else {
+      decoded.push_back(static_cast<char>(0xF0 | ((codepoint >> 18) & 0x07)));
+      decoded.push_back(static_cast<char>(0x80 | ((codepoint >> 12) & 0x3F)));
+      decoded.push_back(static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F)));
+      decoded.push_back(static_cast<char>(0x80 | (codepoint & 0x3F)));
+    }
+    return decoded;
+  }
+
+  return std::nullopt;
+}
+
+std::string DecodeHtmlEntities(std::string_view raw) {
+  std::string decoded;
+  decoded.reserve(raw.size());
+  for (size_t i = 0; i < raw.size(); ++i) {
+    if (raw[i] != '&') {
+      decoded.push_back(raw[i]);
+      continue;
+    }
+    const auto semi = raw.find(';', i + 1);
+    if (semi == std::string_view::npos) {
+      decoded.push_back(raw[i]);
+      continue;
+    }
+    const auto entity = raw.substr(i + 1, semi - i - 1);
+    auto replacement = DecodeHtmlEntity(entity);
+    if (!replacement) {
+      decoded.push_back(raw[i]);
+      continue;
+    }
+    decoded += *replacement;
+    i = semi;
+  }
+  return decoded;
+}
+
+void DecodeHtmlEntitiesInJson(nlohmann::json* value) {
+  if (!value) {
+    return;
+  }
+  if (value->is_string()) {
+    auto& str = value->get_ref<std::string&>();
+    str = DecodeHtmlEntities(str);
+    return;
+  }
+  if (value->is_array()) {
+    for (auto& item : *value) {
+      DecodeHtmlEntitiesInJson(&item);
+    }
+    return;
+  }
+  if (value->is_object()) {
+    for (auto& [_, item] : value->items()) {
+      DecodeHtmlEntitiesInJson(&item);
+    }
+  }
+}
+
+std::string MakeFallbackToolCallId(size_t ordinal) {
+  return "call_auto_" + std::to_string(ordinal);
+}
+
+std::string EnsureUniqueToolCallId(const std::string& preferred,
+                                   std::unordered_set<std::string>* seen_ids) {
+  if (!seen_ids) {
+    return preferred;
+  }
+  std::string candidate = preferred;
+  size_t ordinal = seen_ids->size() + 1;
+  if (!HasNonWhitespace(candidate)) {
+    candidate = MakeFallbackToolCallId(ordinal);
+  }
+  if (seen_ids->insert(candidate).second) {
+    return candidate;
+  }
+  do {
+    candidate = MakeFallbackToolCallId(ordinal++);
+  } while (!seen_ids->insert(candidate).second);
+  return candidate;
+}
+
+std::string ResolveCaseInsensitiveAllowedToolName(
+    std::string_view raw_name,
+    const std::unordered_map<std::string, std::string>& folded_allowed) {
+  auto it = folded_allowed.find(ToLower(raw_name));
+  return it != folded_allowed.end() ? it->second : std::string{};
+}
+
+std::vector<std::string> BuildStructuredToolNameCandidates(
+    std::string_view raw_name) {
+  const std::string trimmed = Trim(raw_name);
+  if (trimmed.empty()) {
+    return {};
+  }
+
+  std::vector<std::string> candidates;
+  std::unordered_set<std::string> seen;
+  auto add = [&](std::string candidate) {
+    candidate = Trim(candidate);
+    if (candidate.empty() || seen.count(candidate) > 0) {
+      return;
+    }
+    seen.insert(candidate);
+    candidates.push_back(std::move(candidate));
+  };
+
+  add(trimmed);
+  add(NormalizeToolNameToken(trimmed));
+
+  std::string normalized_delimiter = trimmed;
+  std::replace(normalized_delimiter.begin(), normalized_delimiter.end(), '/',
+               '.');
+  add(normalized_delimiter);
+  add(NormalizeToolNameToken(normalized_delimiter));
+
+  auto segments = Split(normalized_delimiter, '.');
+  std::vector<std::string> filtered;
+  for (auto& segment : segments) {
+    const auto part = Trim(segment);
+    if (!part.empty()) {
+      filtered.push_back(part);
+    }
+  }
+  if (filtered.size() > 1) {
+    for (size_t index = 1; index < filtered.size(); ++index) {
+      std::string suffix;
+      for (size_t i = index; i < filtered.size(); ++i) {
+        if (!suffix.empty()) {
+          suffix += '.';
+        }
+        suffix += filtered[i];
+      }
+      add(suffix);
+      add(NormalizeToolNameToken(suffix));
+    }
+  }
+
+  return candidates;
+}
+
+std::string ResolveStructuredAllowedToolName(
+    std::string_view raw_name,
+    const std::vector<std::string>& allowed_tool_names,
+    const std::unordered_map<std::string, std::string>& normalized_allowed,
+    const std::unordered_map<std::string, std::string>& folded_allowed) {
+  if (allowed_tool_names.empty()) {
+    return {};
+  }
+
+  for (const auto& candidate : BuildStructuredToolNameCandidates(raw_name)) {
+    if (std::find(allowed_tool_names.begin(), allowed_tool_names.end(),
+                  candidate) != allowed_tool_names.end()) {
+      return candidate;
+    }
+  }
+  for (const auto& candidate : BuildStructuredToolNameCandidates(raw_name)) {
+    auto it = normalized_allowed.find(candidate);
+    if (it != normalized_allowed.end()) {
+      return it->second;
+    }
+  }
+  for (const auto& candidate : BuildStructuredToolNameCandidates(raw_name)) {
+    auto resolved =
+        ResolveCaseInsensitiveAllowedToolName(candidate, folded_allowed);
+    if (!resolved.empty()) {
+      return resolved;
+    }
+  }
+  return {};
+}
+
+std::string InferToolNameFromToolCallId(
+    std::string_view raw_id, const std::vector<std::string>& allowed_tool_names,
+    const std::unordered_map<std::string, std::string>& normalized_allowed,
+    const std::unordered_map<std::string, std::string>& folded_allowed) {
+  const std::string id = Trim(raw_id);
+  if (id.empty() || allowed_tool_names.empty()) {
+    return {};
+  }
+
+  const std::regex trailing_index_re("[:._/-]\\d+$");
+  const std::regex trailing_digits_re("\\d+$");
+  const std::regex function_prefix_re("^functions?[._-]?", std::regex::icase);
+  const std::regex tool_prefix_re("^tools?[._-]?", std::regex::icase);
+
+  std::unordered_set<std::string> candidate_tokens;
+  auto add_token = [&](std::string token) {
+    token = Trim(token);
+    if (token.empty()) {
+      return;
+    }
+    candidate_tokens.insert(token);
+    candidate_tokens.insert(std::regex_replace(token, trailing_index_re, ""));
+    candidate_tokens.insert(std::regex_replace(token, trailing_digits_re, ""));
+
+    std::string normalized_delimiter = token;
+    std::replace(normalized_delimiter.begin(), normalized_delimiter.end(), '/',
+                 '.');
+    candidate_tokens.insert(normalized_delimiter);
+    candidate_tokens.insert(
+        std::regex_replace(normalized_delimiter, trailing_index_re, ""));
+    candidate_tokens.insert(
+        std::regex_replace(normalized_delimiter, trailing_digits_re, ""));
+
+    for (const auto& prefix_pattern : {function_prefix_re, tool_prefix_re}) {
+      auto stripped =
+          std::regex_replace(normalized_delimiter, prefix_pattern, "");
+      if (stripped != normalized_delimiter) {
+        candidate_tokens.insert(stripped);
+        candidate_tokens.insert(
+            std::regex_replace(stripped, trailing_index_re, ""));
+        candidate_tokens.insert(
+            std::regex_replace(stripped, trailing_digits_re, ""));
+      }
+    }
+  };
+
+  const auto colon = id.find(':');
+  add_token(id);
+  add_token(colon == std::string::npos ? id : id.substr(0, colon));
+
+  std::string single_match;
+  for (const auto& token : candidate_tokens) {
+    auto matched = ResolveStructuredAllowedToolName(
+        token, allowed_tool_names, normalized_allowed, folded_allowed);
+    if (matched.empty()) {
+      continue;
+    }
+    if (!single_match.empty() && single_match != matched) {
+      return {};
+    }
+    single_match = matched;
+  }
+  return single_match;
+}
+
+bool LooksLikeMalformedToolNameCounter(std::string_view raw_name) {
+  std::string normalized = Trim(raw_name);
+  std::replace(normalized.begin(), normalized.end(), '/', '.');
+  return std::regex_search(normalized,
+                           std::regex("^(?:functions?|tools?)[._-]?",
+                                      std::regex::icase)) &&
+         std::regex_search(normalized,
+                           std::regex("(?:[:._-]\\d+|\\d+)$"));
+}
+
+std::string ResolveAllowedToolName(
+    std::string_view raw_name, const StreamNormalizationContext& context,
+    std::string_view raw_tool_call_id = {}) {
+  const std::string trimmed = Trim(raw_name);
+  if (trimmed.empty()) {
+    return InferToolNameFromToolCallId(raw_tool_call_id,
+                                       context.allowed_tool_names,
+                                       context.normalized_allowed_tool_names,
+                                       context.folded_allowed_tool_names);
+  }
+  if (context.allowed_tool_names.empty()) {
+    return trimmed;
+  }
+
+  if (std::find(context.allowed_tool_names.begin(),
+                context.allowed_tool_names.end(),
+                trimmed) != context.allowed_tool_names.end()) {
+    return trimmed;
+  }
+
+  auto normalized = NormalizeToolNameToken(trimmed);
+  auto normalized_it = context.normalized_allowed_tool_names.find(normalized);
+  if (normalized_it != context.normalized_allowed_tool_names.end()) {
+    return normalized_it->second;
+  }
+
+  auto case_insensitive = ResolveCaseInsensitiveAllowedToolName(
+      trimmed, context.folded_allowed_tool_names);
+  if (!case_insensitive.empty()) {
+    return case_insensitive;
+  }
+  case_insensitive = ResolveCaseInsensitiveAllowedToolName(
+      normalized, context.folded_allowed_tool_names);
+  if (!case_insensitive.empty()) {
+    return case_insensitive;
+  }
+
+  auto inferred_from_name = InferToolNameFromToolCallId(
+      trimmed, context.allowed_tool_names, context.normalized_allowed_tool_names,
+      context.folded_allowed_tool_names);
+  if (!inferred_from_name.empty()) {
+    return inferred_from_name;
+  }
+
+  if (LooksLikeMalformedToolNameCounter(trimmed)) {
+    return trimmed;
+  }
+
+  auto structured = ResolveStructuredAllowedToolName(
+      trimmed, context.allowed_tool_names, context.normalized_allowed_tool_names,
+      context.folded_allowed_tool_names);
+  return structured.empty() ? trimmed : structured;
+}
+
+nlohmann::json ParseArgumentsWithRepair(std::string_view raw_arguments,
+                                       bool decode_html_entities) {
+  std::string candidate = Trim(raw_arguments);
+  if (decode_html_entities) {
+    candidate = DecodeHtmlEntities(candidate);
+  }
+  if (candidate.empty()) {
+    return nlohmann::json::object();
+  }
+
+  auto parsed = nlohmann::json::parse(candidate, nullptr, false);
+  if (!parsed.is_discarded()) {
+    if (decode_html_entities) {
+      DecodeHtmlEntitiesInJson(&parsed);
+    }
+    return parsed;
+  }
+
+  const auto start = candidate.find_first_of("{[");
+  if (start != std::string::npos) {
+    int depth = 0;
+    bool in_string = false;
+    bool escaped = false;
+    for (size_t i = start; i < candidate.size(); ++i) {
+      const char ch = candidate[i];
+      if (in_string) {
+        if (escaped) {
+          escaped = false;
+        } else if (ch == '\\') {
+          escaped = true;
+        } else if (ch == '"') {
+          in_string = false;
+        }
+        continue;
+      }
+      if (ch == '"') {
+        in_string = true;
+        continue;
+      }
+      if (ch == '{' || ch == '[') {
+        ++depth;
+      } else if (ch == '}' || ch == ']') {
+        --depth;
+        if (depth == 0) {
+          auto repaired = candidate.substr(start, i - start + 1);
+          auto repaired_json = nlohmann::json::parse(repaired, nullptr, false);
+          if (!repaired_json.is_discarded()) {
+            if (decode_html_entities) {
+              DecodeHtmlEntitiesInJson(&repaired_json);
+            }
+            return repaired_json;
+          }
+          break;
+        }
+      }
+    }
+  }
+
+  return nlohmann::json();
+}
+
+bool NormalizeToolCall(ToolCall* tool_call,
+                       const StreamNormalizationContext& context,
+                       std::unordered_set<std::string>* seen_ids,
+                       size_t ordinal) {
+  if (!tool_call) {
+    return false;
+  }
+
+  tool_call->name =
+      ResolveAllowedToolName(tool_call->name, context, tool_call->id);
+  if (!HasNonWhitespace(tool_call->name)) {
+    return false;
+  }
+  if (tool_call->arguments.is_string()) {
+    tool_call->arguments = ParseArgumentsWithRepair(
+        tool_call->arguments.get_ref<const std::string&>(),
+        context.decode_html_entities);
+  }
+  if (context.decode_html_entities) {
+    DecodeHtmlEntitiesInJson(&tool_call->arguments);
+  }
+  if (tool_call->arguments.is_null()) {
+    tool_call->arguments = nlohmann::json::object();
+  }
+  if (!tool_call->arguments.is_object() && !tool_call->arguments.is_array()) {
+    if (context.logger) {
+      context.logger->warn(
+          "Dropping malformed tool call '{}' because arguments are not structured",
+          tool_call->name);
+    }
+    return false;
+  }
+  tool_call->id = EnsureUniqueToolCallId(Trim(tool_call->id), seen_ids);
+  if (tool_call->id.empty()) {
+    tool_call->id =
+        EnsureUniqueToolCallId(MakeFallbackToolCallId(ordinal), seen_ids);
+  }
+  return true;
+}
+
+void NormalizeToolUseBlock(ContentBlock* block,
+                           const StreamNormalizationContext& context,
+                           std::unordered_set<std::string>* seen_ids,
+                           size_t ordinal) {
+  if (!block || block->type != "tool_use") {
+    return;
+  }
+  block->name = ResolveAllowedToolName(block->name, context, block->id);
+  if (context.decode_html_entities) {
+    DecodeHtmlEntitiesInJson(&block->input);
+  }
+  if (block->input.is_null()) {
+    block->input = nlohmann::json::object();
+  }
+  block->id = EnsureUniqueToolCallId(Trim(block->id), seen_ids);
+  if (block->id.empty()) {
+    block->id =
+        EnsureUniqueToolCallId(MakeFallbackToolCallId(ordinal), seen_ids);
+  }
+}
+
+}  // namespace
+
+std::vector<std::string> ExtractAllowedToolNames(
+    const ChatCompletionRequest& request) {
+  std::vector<std::string> names;
+  names.reserve(request.tools.size());
+  for (const auto& tool : request.tools) {
+    if (!tool.is_object()) {
+      continue;
+    }
+    if (tool.value("type", "") != "function") {
+      continue;
+    }
+    if (!tool.contains("function") || !tool["function"].is_object()) {
+      continue;
+    }
+    const auto name = Trim(tool["function"].value("name", std::string{}));
+    if (!name.empty()) {
+      names.push_back(name);
+    }
+  }
+  return names;
+}
+
+StreamNormalizationContext BuildStreamNormalizationContext(
+    const std::string& provider_id, const std::string& api,
+    const ChatCompletionRequest& request,
+    const std::shared_ptr<spdlog::logger>& logger) {
+  StreamNormalizationContext context;
+  context.provider_id = provider_id;
+  context.api = api;
+  context.allowed_tool_names = ExtractAllowedToolNames(request);
+  context.logger = logger;
+
+  const auto folded_provider = ToLower(provider_id);
+  const auto folded_api = ToLower(api);
+  context.decode_html_entities = folded_provider == "xai" ||
+                                 folded_provider == "grok" ||
+                                 folded_api.find("html-entities") !=
+                                     std::string::npos;
+
+  for (const auto& name : context.allowed_tool_names) {
+    context.normalized_allowed_tool_names.emplace(NormalizeToolNameToken(name),
+                                                  name);
+    context.folded_allowed_tool_names.emplace(ToLower(name), name);
+  }
+  return context;
+}
+
+void SanitizeReplayMessages(std::vector<Message>* messages,
+                            const StreamNormalizationContext& context) {
+  if (!messages) {
+    return;
+  }
+  for (auto& message : *messages) {
+    if (message.role != "assistant") {
+      continue;
+    }
+    std::unordered_set<std::string> seen_ids;
+    std::vector<ContentBlock> sanitized;
+    size_t ordinal = 1;
+    for (auto& block : message.content) {
+      if (block.type != "tool_use") {
+        sanitized.push_back(std::move(block));
+        continue;
+      }
+      NormalizeToolUseBlock(&block, context, &seen_ids, ordinal++);
+      if (!HasNonWhitespace(block.name) ||
+          block.name.size() > kReplayToolCallNameMaxChars ||
+          block.name.find_first_of(" \t\r\n") != std::string::npos) {
+        if (context.logger) {
+          context.logger->warn(
+              "Dropping malformed replay tool call with id='{}'", block.id);
+        }
+        continue;
+      }
+      if (block.input.is_null()) {
+        continue;
+      }
+      sanitized.push_back(std::move(block));
+    }
+    message.content = std::move(sanitized);
+  }
+}
+
+void NormalizeToolCalls(std::vector<ToolCall>* tool_calls,
+                        const StreamNormalizationContext& context,
+                        std::unordered_set<std::string>* seen_ids) {
+  if (!tool_calls) {
+    return;
+  }
+  std::vector<ToolCall> normalized;
+  normalized.reserve(tool_calls->size());
+  size_t ordinal = 1;
+  for (auto& tool_call : *tool_calls) {
+    if (NormalizeToolCall(&tool_call, context, seen_ids, ordinal++)) {
+      normalized.push_back(std::move(tool_call));
+    }
+  }
+  *tool_calls = std::move(normalized);
+}
+
+std::vector<ToolCall> FinalizePendingToolCalls(
+    const std::vector<PendingToolCallFragment>& pending,
+    const StreamNormalizationContext& context,
+    std::unordered_set<std::string>* seen_ids,
+    std::vector<PendingToolCallFragment>* remaining) {
+  std::vector<ToolCall> normalized;
+  std::vector<PendingToolCallFragment> unresolved;
+  normalized.reserve(pending.size());
+
+  size_t ordinal = 1;
+  for (const auto& fragment : pending) {
+    ToolCall tool_call;
+    tool_call.id = fragment.id;
+    tool_call.name = fragment.name;
+    tool_call.arguments =
+        ParseArgumentsWithRepair(fragment.arguments, context.decode_html_entities);
+
+    if (HasNonWhitespace(fragment.arguments) && tool_call.arguments.is_null()) {
+      unresolved.push_back(fragment);
+      continue;
+    }
+    if (NormalizeToolCall(&tool_call, context, seen_ids, ordinal++)) {
+      normalized.push_back(std::move(tool_call));
+    } else if (remaining) {
+      unresolved.push_back(fragment);
+    }
+  }
+
+  if (remaining) {
+    *remaining = std::move(unresolved);
+  }
+  return normalized;
+}
+
+}  // namespace quantclaw

--- a/tests/test_openai_provider.cpp
+++ b/tests/test_openai_provider.cpp
@@ -1,8 +1,11 @@
 // Copyright 2025 QuantClaw Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <atomic>
 #include <memory>
+#include <thread>
 
+#include <httplib.h>
 #include <nlohmann/json.hpp>
 #include <spdlog/sinks/null_sink.h>
 #include <spdlog/spdlog.h>
@@ -10,6 +13,7 @@
 #include "quantclaw/providers/llm_provider.hpp"
 #include "quantclaw/providers/openai_provider.hpp"
 
+#include "test_helpers.hpp"
 #include <gtest/gtest.h>
 
 namespace quantclaw::detail {
@@ -239,6 +243,163 @@ TEST_F(OpenAIProviderTest, ConstructionWithCustomBaseUrl) {
     quantclaw::OpenAIProvider provider("key", "https://custom.api.com/v1", 30,
                                        logger_);
   });
+}
+
+TEST(OpenAIProviderCompatibilityTest,
+     ChatCompletionRepairsCompatibleToolCallNameAndArguments) {
+  const int port = quantclaw::test::FindFreePort();
+  ASSERT_GT(port, 0);
+
+  httplib::Server server;
+  std::atomic<bool> saw_request = false;
+  server.Post("/chat/completions", [&](const httplib::Request& req,
+                                        httplib::Response& res) {
+    saw_request = true;
+    const auto body = nlohmann::json::parse(req.body);
+    EXPECT_EQ(body.value("model", ""), "qwen3-max");
+    ASSERT_TRUE(body.contains("tools"));
+
+    nlohmann::json tool_call = {
+        {"id", "function.read:1"},
+        {"type", "function"},
+        {"function",
+         {{"name", " functions.read "},
+          {"arguments", "prefix {\"path\":\"/tmp/a.txt\"}x"}}},
+    };
+    nlohmann::json choice = {
+        {"message",
+         {{"content", nullptr},
+          {"tool_calls", nlohmann::json::array({tool_call})}}},
+        {"finish_reason", "tool_calls"},
+    };
+    nlohmann::json response = {
+        {"choices", nlohmann::json::array({choice})},
+    };
+    res.set_content(response.dump(), "application/json");
+  });
+
+  std::thread server_thread([&]() {
+    quantclaw::test::ReleaseHeldPort(port);
+    server.listen("127.0.0.1", port);
+  });
+  ASSERT_TRUE(quantclaw::test::WaitForServerReady(port, 5000));
+
+  auto null_sink = std::make_shared<spdlog::sinks::null_sink_mt>();
+  auto logger =
+      std::make_shared<spdlog::logger>("openai-compatible-sync", null_sink);
+  quantclaw::OpenAIProvider provider(
+      "test-key", "http://127.0.0.1:" + std::to_string(port), 30, logger);
+
+  quantclaw::ChatCompletionRequest request;
+  request.model = "qwen3-max";
+  request.messages.push_back({"user", "Read a file"});
+  request.tools.push_back({{"type", "function"},
+                           {"function",
+                            {{"name", "read"},
+                             {"description", "Read file"},
+                             {"parameters",
+                              {{"type", "object"},
+                               {"properties",
+                                {{{"path", {{"type", "string"}}}}}}}}}}});
+
+  quantclaw::ChatCompletionResponse response;
+  try {
+    response = provider.ChatCompletion(request);
+  } catch (const std::exception& e) {
+    ADD_FAILURE() << "ChatCompletion threw: " << e.what();
+  }
+
+  server.stop();
+  server_thread.join();
+
+  ASSERT_TRUE(saw_request.load());
+  EXPECT_EQ(response.finish_reason, "tool_calls");
+  ASSERT_EQ(response.tool_calls.size(), 1u);
+  EXPECT_EQ(response.tool_calls[0].id, "function.read:1");
+  EXPECT_EQ(response.tool_calls[0].name, "read");
+  EXPECT_EQ(response.tool_calls[0].arguments["path"], "/tmp/a.txt");
+}
+
+TEST(OpenAIProviderCompatibilityTest, StreamingRepairsSplitToolCallAcrossChunks) {
+  const int port = quantclaw::test::FindFreePort();
+  ASSERT_GT(port, 0);
+
+  httplib::Server server;
+  std::atomic<bool> saw_request = false;
+  server.Post("/chat/completions", [&](const httplib::Request& req,
+                                        httplib::Response& res) {
+    saw_request = true;
+    const auto body = nlohmann::json::parse(req.body);
+    EXPECT_EQ(body.value("model", ""), "qwen3-max");
+    EXPECT_TRUE(body.value("stream", false));
+    ASSERT_TRUE(body.contains("tools"));
+
+    res.set_chunked_content_provider(
+        "text/event-stream", [](size_t /*offset*/, httplib::DataSink& sink) {
+          const char part1[] =
+              "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,"
+              "\"id\":\"function.read:1\",\"function\":{\"name\":\" "
+              "functions.read \",\"arguments\":\"prefix {\\\"path\\\":\""
+              "}}]}}]}\n\n";
+          const char part2[] =
+              "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,"
+              "\"function\":{\"arguments\":\"\\\"/tmp/a.txt\\\"}x\"}}]},"
+              "\"finish_reason\":\"tool_calls\"}]}\n\n";
+          const char part3[] = "data: [DONE]\n\n";
+          sink.write(part1, sizeof(part1) - 1);
+          sink.write(part2, sizeof(part2) - 1);
+          sink.write(part3, sizeof(part3) - 1);
+          sink.done();
+          return true;
+        });
+  });
+
+  std::thread server_thread([&]() {
+    quantclaw::test::ReleaseHeldPort(port);
+    server.listen("127.0.0.1", port);
+  });
+  ASSERT_TRUE(quantclaw::test::WaitForServerReady(port, 5000));
+
+  auto null_sink = std::make_shared<spdlog::sinks::null_sink_mt>();
+  auto logger =
+      std::make_shared<spdlog::logger>("openai-compatible-stream", null_sink);
+  quantclaw::OpenAIProvider provider(
+      "test-key", "http://127.0.0.1:" + std::to_string(port), 30, logger);
+
+  quantclaw::ChatCompletionRequest request;
+  request.model = "qwen3-max";
+  request.stream = true;
+  request.messages.push_back({"user", "Read a file"});
+  request.tools.push_back({{"type", "function"},
+                           {"function",
+                            {{"name", "read"},
+                             {"description", "Read file"},
+                             {"parameters",
+                              {{"type", "object"},
+                               {"properties",
+                                {{{"path", {{"type", "string"}}}}}}}}}}});
+
+  std::vector<quantclaw::ChatCompletionResponse> chunks;
+  try {
+    provider.ChatCompletionStream(
+        request, [&](const quantclaw::ChatCompletionResponse& chunk) {
+          chunks.push_back(chunk);
+        });
+  } catch (const std::exception& e) {
+    ADD_FAILURE() << "ChatCompletionStream threw: " << e.what();
+  }
+
+  server.stop();
+  server_thread.join();
+
+  ASSERT_TRUE(saw_request.load());
+  ASSERT_EQ(chunks.size(), 2u);
+  EXPECT_EQ(chunks[0].finish_reason, "tool_calls");
+  ASSERT_EQ(chunks[0].tool_calls.size(), 1u);
+  EXPECT_EQ(chunks[0].tool_calls[0].id, "function.read:1");
+  EXPECT_EQ(chunks[0].tool_calls[0].name, "read");
+  EXPECT_EQ(chunks[0].tool_calls[0].arguments["path"], "/tmp/a.txt");
+  EXPECT_TRUE(chunks[1].is_stream_end);
 }
 
 TEST(OpenAIProviderJsonTest, NullableStringReturnsEmptyForNull) {

--- a/tests/test_openai_provider.cpp
+++ b/tests/test_openai_provider.cpp
@@ -252,31 +252,31 @@ TEST(OpenAIProviderCompatibilityTest,
 
   httplib::Server server;
   std::atomic<bool> saw_request = false;
-  server.Post("/chat/completions", [&](const httplib::Request& req,
-                                        httplib::Response& res) {
-    saw_request = true;
-    const auto body = nlohmann::json::parse(req.body);
-    EXPECT_EQ(body.value("model", ""), "qwen3-max");
-    ASSERT_TRUE(body.contains("tools"));
+  server.Post("/chat/completions",
+              [&](const httplib::Request& req, httplib::Response& res) {
+                saw_request = true;
+                const auto body = nlohmann::json::parse(req.body);
+                EXPECT_EQ(body.value("model", ""), "qwen3-max");
+                ASSERT_TRUE(body.contains("tools"));
 
-    nlohmann::json tool_call = {
-        {"id", "function.read:1"},
-        {"type", "function"},
-        {"function",
-         {{"name", " functions.read "},
-          {"arguments", "prefix {\"path\":\"/tmp/a.txt\"}x"}}},
-    };
-    nlohmann::json choice = {
-        {"message",
-         {{"content", nullptr},
-          {"tool_calls", nlohmann::json::array({tool_call})}}},
-        {"finish_reason", "tool_calls"},
-    };
-    nlohmann::json response = {
-        {"choices", nlohmann::json::array({choice})},
-    };
-    res.set_content(response.dump(), "application/json");
-  });
+                nlohmann::json tool_call = {
+                    {"id", "function.read:1"},
+                    {"type", "function"},
+                    {"function",
+                     {{"name", " functions.read "},
+                      {"arguments", "prefix {\"path\":\"/tmp/a.txt\"}x"}}},
+                };
+                nlohmann::json choice = {
+                    {"message",
+                     {{"content", nullptr},
+                      {"tool_calls", nlohmann::json::array({tool_call})}}},
+                    {"finish_reason", "tool_calls"},
+                };
+                nlohmann::json response = {
+                    {"choices", nlohmann::json::array({choice})},
+                };
+                res.set_content(response.dump(), "application/json");
+              });
 
   std::thread server_thread([&]() {
     quantclaw::test::ReleaseHeldPort(port);
@@ -293,14 +293,14 @@ TEST(OpenAIProviderCompatibilityTest,
   quantclaw::ChatCompletionRequest request;
   request.model = "qwen3-max";
   request.messages.push_back({"user", "Read a file"});
-  request.tools.push_back({{"type", "function"},
-                           {"function",
-                            {{"name", "read"},
-                             {"description", "Read file"},
-                             {"parameters",
-                              {{"type", "object"},
-                               {"properties",
-                                {{{"path", {{"type", "string"}}}}}}}}}}});
+  request.tools.push_back(
+      {{"type", "function"},
+       {"function",
+        {{"name", "read"},
+         {"description", "Read file"},
+         {"parameters",
+          {{"type", "object"},
+           {"properties", {{{"path", {{"type", "string"}}}}}}}}}}});
 
   quantclaw::ChatCompletionResponse response;
   try {
@@ -320,14 +320,15 @@ TEST(OpenAIProviderCompatibilityTest,
   EXPECT_EQ(response.tool_calls[0].arguments["path"], "/tmp/a.txt");
 }
 
-TEST(OpenAIProviderCompatibilityTest, StreamingRepairsSplitToolCallAcrossChunks) {
+TEST(OpenAIProviderCompatibilityTest,
+     StreamingRepairsSplitToolCallAcrossChunks) {
   const int port = quantclaw::test::FindFreePort();
   ASSERT_GT(port, 0);
 
   httplib::Server server;
   std::atomic<bool> saw_request = false;
   server.Post("/chat/completions", [&](const httplib::Request& req,
-                                        httplib::Response& res) {
+                                       httplib::Response& res) {
     saw_request = true;
     const auto body = nlohmann::json::parse(req.body);
     EXPECT_EQ(body.value("model", ""), "qwen3-max");
@@ -370,14 +371,14 @@ TEST(OpenAIProviderCompatibilityTest, StreamingRepairsSplitToolCallAcrossChunks)
   request.model = "qwen3-max";
   request.stream = true;
   request.messages.push_back({"user", "Read a file"});
-  request.tools.push_back({{"type", "function"},
-                           {"function",
-                            {{"name", "read"},
-                             {"description", "Read file"},
-                             {"parameters",
-                              {{"type", "object"},
-                               {"properties",
-                                {{{"path", {{"type", "string"}}}}}}}}}}});
+  request.tools.push_back(
+      {{"type", "function"},
+       {"function",
+        {{"name", "read"},
+         {"description", "Read file"},
+         {"parameters",
+          {{"type", "object"},
+           {"properties", {{{"path", {{"type", "string"}}}}}}}}}}});
 
   std::vector<quantclaw::ChatCompletionResponse> chunks;
   try {

--- a/tests/test_provider_registry.cpp
+++ b/tests/test_provider_registry.cpp
@@ -4,6 +4,8 @@
 #include <spdlog/sinks/null_sink.h>
 #include <spdlog/spdlog.h>
 
+#include "quantclaw/providers/anthropic_provider.hpp"
+#include "quantclaw/providers/openai_provider.hpp"
 #include "quantclaw/providers/provider_registry.hpp"
 
 #include <gtest/gtest.h>
@@ -140,6 +142,38 @@ TEST(ProviderRegistryTest, GetProviderCreatesInstance) {
   // Second call returns same instance
   auto provider2 = reg->GetProvider("openai");
   EXPECT_EQ(provider.get(), provider2.get());
+}
+
+TEST(ProviderRegistryTest, LoadFromConfigApiFieldSelectsCompatibleFactory) {
+  auto reg = std::make_unique<ProviderRegistry>(make_logger("providers"));
+  reg->RegisterBuiltinFactories();
+
+  nlohmann::json config = {
+      {"qwen",
+       {{"apiKey", "test-key"},
+        {"api", "openai-completions"},
+        {"baseUrl", "https://dashscope.aliyuncs.com/compatible-mode/v1"}}},
+  };
+  reg->LoadFromConfig(config);
+
+  auto provider = reg->GetProvider("qwen");
+  ASSERT_NE(provider, nullptr);
+  EXPECT_NE(dynamic_cast<OpenAIProvider*>(provider.get()), nullptr);
+}
+
+TEST(ProviderRegistryTest, GetProviderWithKeyUsesApiMappedFactory) {
+  auto reg = std::make_unique<ProviderRegistry>(make_logger("providers"));
+  reg->RegisterBuiltinFactories();
+
+  ProviderEntry entry;
+  entry.id = "kimi";
+  entry.api = "anthropic-messages";
+  entry.base_url = "https://api.moonshot.ai";
+  reg->AddProvider(entry);
+
+  auto provider = reg->GetProviderWithKey("kimi", "override-key");
+  ASSERT_NE(provider, nullptr);
+  EXPECT_NE(dynamic_cast<AnthropicProvider*>(provider.get()), nullptr);
 }
 
 TEST(ProviderRegistryTest, OpenAICodexBuiltinFactoryCreatesProvider) {


### PR DESCRIPTION
## Summary
- extract OpenAI-compatible tool call normalization into a shared helper used by the OpenAI provider
- repair malformed or fragmented tool calls for both sync and streaming responses
- honor provider `api` routing in the registry so compatible providers like Qwen and Kimi resolve to the right backend
- keep this PR clean and focused by excluding the unrelated `package-lock` drift from #115

## Testing
- `./build-wsl/quantclaw_tests --gtest_filter='''OpenAIProvider*:ProviderRegistryTest.*'''`

## Notes
- this is the clean follow-up to #115