### PR TITLE
fix: handle stale Telegram tool-result history

### DIFF
--- a/src/adapters/base.test.ts
+++ b/src/adapters/base.test.ts
@@ -24,6 +24,12 @@ class TestAdapter extends ChannelAdapter {
   }
 }
 
+class FailingAdapter extends TestAdapter {
+  async agentRequest(): Promise<string> {
+    throw new Error("provider rejected malformed history");
+  }
+}
+
 function withChannelConfig(
   config: Record<string, unknown>,
   fn: () => Promise<void>
@@ -140,4 +146,17 @@ test("default gateway URL is ws://127.0.0.1:18800 when env is unset", () => {
   } else {
     process.env.QUANTCLAW_GATEWAY_URL = prev;
   }
+});
+
+test("processing failures are sent with the actual error summary", async () => {
+  await withChannelConfig({ token: "t" }, async () => {
+    const adapter = new FailingAdapter();
+    await adapter.handlePlatformMessage("user-1", "channel-1", "hello");
+
+    assert.equal(adapter.sent.length, 1);
+    assert.equal(
+      adapter.sent[0].text,
+      "Error processing your message: provider rejected malformed history"
+    );
+  });
 });

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -41,7 +41,7 @@ interface RpcResponse {
   id: string;
   ok: boolean;
   payload?: unknown;
-  error?: string;
+  error?: unknown;
 }
 
 interface RpcEvent {
@@ -51,6 +51,23 @@ interface RpcEvent {
 }
 
 type GatewayFrame = RpcResponse | RpcEvent;
+
+function errorSummary(err: unknown): string {
+  if (err instanceof Error && err.message) return err.message;
+  if (typeof err === "string") return err;
+  if (err && typeof err === "object") {
+    const maybeMessage = (err as { message?: unknown }).message;
+    if (typeof maybeMessage === "string" && maybeMessage) {
+      return maybeMessage;
+    }
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return String(err);
+    }
+  }
+  return String(err || "unknown error");
+}
 
 // ---- Base Adapter ----
 
@@ -163,7 +180,7 @@ export abstract class ChannelAdapter {
             if (resp.ok) {
               p.resolve(resp.payload);
             } else {
-              p.reject(new Error(resp.error ?? "RPC error"));
+              p.reject(new Error(errorSummary(resp.error ?? "RPC error")));
             }
           }
         }
@@ -371,7 +388,7 @@ export abstract class ChannelAdapter {
       console.error("[adapter] Failed to process message:", err);
       await this.sendToPlatform(
         channelId,
-        "Error processing your message.",
+        `Error processing your message: ${errorSummary(err)}`,
         replyTo
       );
     }

--- a/src/providers/openai_provider.cpp
+++ b/src/providers/openai_provider.cpp
@@ -84,6 +84,7 @@ nlohmann::json
 serialize_messages_to_openai(const std::vector<Message>& messages,
                              bool thinking_enabled) {
   nlohmann::json arr = nlohmann::json::array();
+  std::unordered_set<std::string> pending_tool_result_ids;
 
   for (const auto& msg : messages) {
     std::string text_content = message_text_content(msg);
@@ -100,9 +101,13 @@ serialize_messages_to_openai(const std::vector<Message>& messages,
     }
 
     if (has_tool_result) {
-      // Expand into separate OpenAI "tool" role messages
+      // OpenAI requires tool result messages to immediately answer the
+      // previous assistant tool_calls turn. Session truncation can leave stale
+      // tool_result blocks behind, so skip unmatched results instead of
+      // sending an invalid replay payload.
       for (const auto& b : msg.content) {
-        if (b.type == "tool_result") {
+        if (b.type == "tool_result" &&
+            pending_tool_result_ids.erase(b.tool_use_id) > 0) {
           arr.push_back({{"role", "tool"},
                          {"tool_call_id", b.tool_use_id},
                          {"content", b.content}});
@@ -135,7 +140,14 @@ serialize_messages_to_openai(const std::vector<Message>& messages,
       }
       j["tool_calls"] = tool_calls;
       arr.push_back(j);
+      pending_tool_result_ids.clear();
+      for (const auto& b : msg.content) {
+        if (b.type == "tool_use" && !b.id.empty()) {
+          pending_tool_result_ids.insert(b.id);
+        }
+      }
     } else {
+      pending_tool_result_ids.clear();
       // Plain text message (system, user, or assistant)
       nlohmann::json j = {{"role", msg.role}, {"content", text_content}};
       if (msg.role == "assistant" && !reasoning_content.empty()) {

--- a/tests/test_openai_provider.cpp
+++ b/tests/test_openai_provider.cpp
@@ -245,6 +245,73 @@ TEST_F(OpenAIProviderTest, ConstructionWithCustomBaseUrl) {
   });
 }
 
+TEST(OpenAIProviderCompatibilityTest, ChatCompletionSkipsOrphanToolResults) {
+  const int port = quantclaw::test::FindFreePort();
+  ASSERT_GT(port, 0);
+
+  httplib::Server server;
+  std::atomic<bool> saw_request = false;
+  std::atomic<bool> saw_orphan_tool_message = false;
+  server.Post("/chat/completions", [&](const httplib::Request& req,
+                                       httplib::Response& res) {
+    saw_request = true;
+    const auto body = nlohmann::json::parse(req.body);
+    ASSERT_TRUE(body.contains("messages"));
+    for (const auto& message : body["messages"]) {
+      if (message.value("role", "") == "tool" &&
+          message.value("tool_call_id", "") == "orphan-call") {
+        saw_orphan_tool_message = true;
+      }
+    }
+
+    nlohmann::json response = {
+        {"choices", nlohmann::json::array({{{"message", {{"content", "ok"}}},
+                                            {"finish_reason", "stop"}}})},
+    };
+    res.set_content(response.dump(), "application/json");
+  });
+
+  std::thread server_thread([&]() {
+    quantclaw::test::ReleaseHeldPort(port);
+    server.listen("127.0.0.1", port);
+  });
+  auto stop_server = [&]() {
+    server.stop();
+    if (server_thread.joinable()) {
+      server_thread.join();
+    }
+  };
+  if (!quantclaw::test::WaitForServerReady(port, 5000)) {
+    stop_server();
+    FAIL() << "Server not ready on port " << port;
+  }
+
+  auto null_sink = std::make_shared<spdlog::sinks::null_sink_mt>();
+  auto logger =
+      std::make_shared<spdlog::logger>("openai-orphan-tool", null_sink);
+  quantclaw::OpenAIProvider provider(
+      "test-key", "http://127.0.0.1:" + std::to_string(port), 30, logger);
+
+  quantclaw::ChatCompletionRequest request;
+  request.model = "qwen3-max";
+  request.messages.push_back({"user", "before"});
+
+  quantclaw::Message orphan_tool_result;
+  orphan_tool_result.role = "user";
+  orphan_tool_result.content.push_back(
+      quantclaw::ContentBlock::MakeToolResult("orphan-call", "stale output"));
+  request.messages.push_back(std::move(orphan_tool_result));
+
+  request.messages.push_back({"user", "after"});
+
+  auto response = provider.ChatCompletion(request);
+  stop_server();
+
+  ASSERT_TRUE(saw_request.load());
+  EXPECT_FALSE(saw_orphan_tool_message.load());
+  EXPECT_EQ(response.content, "ok");
+}
+
 TEST(OpenAIProviderCompatibilityTest,
      ChatCompletionRepairsCompatibleToolCallNameAndArguments) {
   const int port = quantclaw::test::FindFreePort();


### PR DESCRIPTION
## Summary

Fixes Telegram/adapter conversations getting stuck behind a generic `Error processing your message.` after older session history contains stale tool-result turns.

## Root Cause

OpenAI-compatible chat APIs require every `role=tool` message to directly answer a preceding assistant message with a matching `tool_calls` entry. QuantClaw session replay can include historical or truncated `tool_result` blocks that no longer have a matching immediately preceding tool call, causing the provider request to fail with HTTP 400.

The Telegram adapter then hid the gateway error behind a fixed fallback string, making the actual failure opaque from the external client.

## Changes

- Skip unmatched/stale OpenAI `tool_result` blocks during provider message serialization instead of sending an invalid replay payload.
- Preserve matched tool results for the immediately preceding assistant tool-call turn.
- Return adapter processing failures with the actual error summary instead of a generic fixed message.
- Add regression coverage for orphan tool-result serialization and adapter error reporting.

## Validation

- `./cmake-build-debug/quantclaw_tests --gtest_filter='OpenAIProviderCompatibilityTest.*'`
- `npx tsx --test base.test.ts`
