### PR TITLE
fix: skip orphan tool results in openai codex provider

### DIFF
--- a/src/providers/openai_codex_provider.cpp
+++ b/src/providers/openai_codex_provider.cpp
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 #include <curl/curl.h>
 #include <nlohmann/json.hpp>
@@ -43,6 +44,7 @@ convert_tools_to_responses(const std::vector<nlohmann::json>& tools) {
 nlohmann::json build_input_items(const std::vector<Message>& messages,
                                  std::string* instructions) {
   nlohmann::json input = nlohmann::json::array();
+  std::unordered_set<std::string> pending_tool_result_ids;
 
   for (const auto& msg : messages) {
     const std::string text = msg.text();
@@ -67,7 +69,8 @@ nlohmann::json build_input_items(const std::vector<Message>& messages,
 
     if (has_tool_result) {
       for (const auto& block : msg.content) {
-        if (block.type == "tool_result") {
+        if (block.type == "tool_result" &&
+            pending_tool_result_ids.erase(block.tool_use_id) > 0) {
           input.push_back({{"type", "function_call_output"},
                            {"call_id", block.tool_use_id},
                            {"output", block.content}});
@@ -88,9 +91,16 @@ nlohmann::json build_input_items(const std::vector<Message>& messages,
       if (!text.empty()) {
         input.push_back({{"role", "assistant"}, {"content", text}});
       }
+      pending_tool_result_ids.clear();
+      for (const auto& block : msg.content) {
+        if (block.type == "tool_use" && !block.id.empty()) {
+          pending_tool_result_ids.insert(block.id);
+        }
+      }
       continue;
     }
 
+    pending_tool_result_ids.clear();
     input.push_back({{"role", msg.role}, {"content", text}});
   }
 

--- a/tests/test_openai_codex_provider.cpp
+++ b/tests/test_openai_codex_provider.cpp
@@ -171,6 +171,101 @@ TEST(OpenAICodexProviderTest, StreamingParsesTextDeltas) {
   server_thread.join();
 }
 
+TEST(OpenAICodexProviderTest, ChatCompletionSkipsOrphanToolResults) {
+  const int port = test::FindFreePort();
+  ASSERT_GT(port, 0);
+
+  httplib::Server server;
+  std::atomic<bool> saw_request = false;
+  std::atomic<bool> saw_function_call = false;
+  std::atomic<bool> saw_matched_output = false;
+  std::atomic<bool> saw_orphan_output = false;
+  server.Post("/codex/responses", [&](const httplib::Request& req,
+                                      httplib::Response& res) {
+    saw_request = true;
+    EXPECT_EQ(req.get_header_value("Authorization"), "Bearer oauth-token");
+
+    const auto body = nlohmann::json::parse(req.body);
+    ASSERT_TRUE(body.contains("input"));
+    ASSERT_TRUE(body["input"].is_array());
+
+    for (const auto& item : body["input"]) {
+      if (item.value("type", "") == "function_call" &&
+          item.value("call_id", "") == "matched-call") {
+        saw_function_call = true;
+      }
+      if (item.value("type", "") == "function_call_output" &&
+          item.value("call_id", "") == "matched-call") {
+        saw_matched_output = true;
+      }
+      if (item.value("type", "") == "function_call_output" &&
+          item.value("call_id", "") == "orphan-call") {
+        saw_orphan_output = true;
+      }
+    }
+
+    res.set_chunked_content_provider(
+        "text/event-stream", [](size_t /*offset*/, httplib::DataSink& sink) {
+          const char event1[] =
+              "data: {\"type\":\"response.output_text.delta\",\"delta\":"
+              "\"ok\"}\n\n";
+          const char event2[] =
+              "data: {\"type\":\"response.completed\",\"response\":"
+              "{\"status\":\"completed\"}}\n\n";
+          sink.write(event1, sizeof(event1) - 1);
+          sink.write(event2, sizeof(event2) - 1);
+          sink.done();
+          return true;
+        });
+  });
+
+  std::thread server_thread([&]() {
+    test::ReleaseHeldPort(port);
+    server.listen("127.0.0.1", port);
+  });
+  ASSERT_TRUE(test::WaitForServerReady(port));
+
+  auto logger = make_logger("openai-codex-provider-orphan-tool");
+  auto token_source = std::make_shared<FakeBearerTokenSource>();
+  OpenAICodexProvider provider("http://127.0.0.1:" + std::to_string(port), 30,
+                               logger, token_source);
+
+  ChatCompletionRequest request;
+  request.model = "gpt-5";
+  request.messages.push_back({"user", "before"});
+
+  Message assistant_tool_call;
+  assistant_tool_call.role = "assistant";
+  assistant_tool_call.content.push_back(
+      ContentBlock::MakeToolUse("matched-call", "read_file",
+                                {{"path", "/tmp/a.txt"}}));
+  request.messages.push_back(std::move(assistant_tool_call));
+
+  Message matched_tool_result;
+  matched_tool_result.role = "user";
+  matched_tool_result.content.push_back(
+      ContentBlock::MakeToolResult("matched-call", "file contents"));
+  request.messages.push_back(std::move(matched_tool_result));
+
+  Message orphan_tool_result;
+  orphan_tool_result.role = "user";
+  orphan_tool_result.content.push_back(
+      ContentBlock::MakeToolResult("orphan-call", "stale output"));
+  request.messages.push_back(std::move(orphan_tool_result));
+
+  request.messages.push_back({"user", "after"});
+
+  const auto response = provider.ChatCompletion(request);
+  EXPECT_TRUE(saw_request.load());
+  EXPECT_TRUE(saw_function_call.load());
+  EXPECT_TRUE(saw_matched_output.load());
+  EXPECT_FALSE(saw_orphan_output.load());
+  EXPECT_EQ(response.content, "ok");
+
+  server.stop();
+  server_thread.join();
+}
+
 TEST(OpenAICodexProviderTest,
      ChatCompletionPrefersHttpClassificationWhenSseReportsError) {
   const int port = test::FindFreePort();

--- a/tests/test_openai_codex_provider.cpp
+++ b/tests/test_openai_codex_provider.cpp
@@ -236,9 +236,8 @@ TEST(OpenAICodexProviderTest, ChatCompletionSkipsOrphanToolResults) {
 
   Message assistant_tool_call;
   assistant_tool_call.role = "assistant";
-  assistant_tool_call.content.push_back(
-      ContentBlock::MakeToolUse("matched-call", "read_file",
-                                {{"path", "/tmp/a.txt"}}));
+  assistant_tool_call.content.push_back(ContentBlock::MakeToolUse(
+      "matched-call", "read_file", {{"path", "/tmp/a.txt"}}));
   request.messages.push_back(std::move(assistant_tool_call));
 
   Message matched_tool_result;

--- a/tests/test_openai_provider.cpp
+++ b/tests/test_openai_provider.cpp
@@ -313,6 +313,350 @@ TEST(OpenAIProviderCompatibilityTest, ChatCompletionSkipsOrphanToolResults) {
 }
 
 TEST(OpenAIProviderCompatibilityTest,
+     ChatCompletionSkipsMultipleOrphanToolResults) {
+  const int port = quantclaw::test::FindFreePort();
+  ASSERT_GT(port, 0);
+
+  httplib::Server server;
+  std::atomic<int> tool_message_count{0};
+  server.Post("/chat/completions", [&](const httplib::Request& req,
+                                       httplib::Response& res) {
+    const auto body = nlohmann::json::parse(req.body);
+    ASSERT_TRUE(body.contains("messages"));
+    for (const auto& message : body["messages"]) {
+      if (message.value("role", "") == "tool") {
+        tool_message_count++;
+      }
+    }
+
+    nlohmann::json response = {
+        {"choices", nlohmann::json::array({{{"message", {{"content", "ok"}}},
+                                            {"finish_reason", "stop"}}})},
+    };
+    res.set_content(response.dump(), "application/json");
+  });
+
+  std::thread server_thread([&]() {
+    quantclaw::test::ReleaseHeldPort(port);
+    server.listen("127.0.0.1", port);
+  });
+  auto stop_server = [&]() {
+    server.stop();
+    if (server_thread.joinable()) {
+      server_thread.join();
+    }
+  };
+  if (!quantclaw::test::WaitForServerReady(port, 5000)) {
+    stop_server();
+    FAIL() << "Server not ready on port " << port;
+  }
+
+  auto null_sink = std::make_shared<spdlog::sinks::null_sink_mt>();
+  auto logger =
+      std::make_shared<spdlog::logger>("openai-multi-orphan", null_sink);
+  quantclaw::OpenAIProvider provider(
+      "test-key", "http://127.0.0.1:" + std::to_string(port), 30, logger);
+
+  quantclaw::ChatCompletionRequest request;
+  request.model = "qwen3-max";
+  request.messages.push_back({"user", "before"});
+
+  // Three orphan tool results with no preceding assistant tool_calls
+  for (int i = 0; i < 3; ++i) {
+    quantclaw::Message orphan;
+    orphan.role = "user";
+    orphan.content.push_back(quantclaw::ContentBlock::MakeToolResult(
+        "orphan-" + std::to_string(i), "stale"));
+    request.messages.push_back(std::move(orphan));
+  }
+
+  request.messages.push_back({"user", "after"});
+
+  auto response = provider.ChatCompletion(request);
+  stop_server();
+
+  EXPECT_EQ(tool_message_count.load(), 0);
+  EXPECT_EQ(response.content, "ok");
+}
+
+TEST(OpenAIProviderCompatibilityTest,
+     ChatCompletionPreservesMatchedToolResults) {
+  const int port = quantclaw::test::FindFreePort();
+  ASSERT_GT(port, 0);
+
+  httplib::Server server;
+  std::atomic<int> tool_message_count{0};
+  std::vector<std::string> seen_tool_ids;
+  server.Post("/chat/completions", [&](const httplib::Request& req,
+                                       httplib::Response& res) {
+    const auto body = nlohmann::json::parse(req.body);
+    ASSERT_TRUE(body.contains("messages"));
+    for (const auto& message : body["messages"]) {
+      if (message.value("role", "") == "tool") {
+        tool_message_count++;
+        seen_tool_ids.push_back(message.value("tool_call_id", ""));
+      }
+    }
+
+    nlohmann::json response = {
+        {"choices", nlohmann::json::array({{{"message", {{"content", "ok"}}},
+                                            {"finish_reason", "stop"}}})},
+    };
+    res.set_content(response.dump(), "application/json");
+  });
+
+  std::thread server_thread([&]() {
+    quantclaw::test::ReleaseHeldPort(port);
+    server.listen("127.0.0.1", port);
+  });
+  auto stop_server = [&]() {
+    server.stop();
+    if (server_thread.joinable()) {
+      server_thread.join();
+    }
+  };
+  if (!quantclaw::test::WaitForServerReady(port, 5000)) {
+    stop_server();
+    FAIL() << "Server not ready on port " << port;
+  }
+
+  auto null_sink = std::make_shared<spdlog::sinks::null_sink_mt>();
+  auto logger =
+      std::make_shared<spdlog::logger>("openai-matched-tool", null_sink);
+  quantclaw::OpenAIProvider provider(
+      "test-key", "http://127.0.0.1:" + std::to_string(port), 30, logger);
+
+  quantclaw::ChatCompletionRequest request;
+  request.model = "qwen3-max";
+  request.messages.push_back({"user", "run tool"});
+
+  // Assistant message with tool_use
+  quantclaw::Message assistant;
+  assistant.role = "assistant";
+  assistant.content.push_back(
+      quantclaw::ContentBlock::MakeText("Calling tool"));
+  assistant.content.push_back(
+      quantclaw::ContentBlock::MakeToolUse("call-1", "read", {{"path", "/x"}}));
+  request.messages.push_back(std::move(assistant));
+
+  // Matching tool_result
+  quantclaw::Message tool_result;
+  tool_result.role = "user";
+  tool_result.content.push_back(
+      quantclaw::ContentBlock::MakeToolResult("call-1", "file contents"));
+  request.messages.push_back(std::move(tool_result));
+
+  request.messages.push_back({"user", "thanks"});
+
+  auto response = provider.ChatCompletion(request);
+  stop_server();
+
+  ASSERT_EQ(tool_message_count.load(), 1);
+  EXPECT_EQ(seen_tool_ids[0], "call-1");
+  EXPECT_EQ(response.content, "ok");
+}
+
+TEST(OpenAIProviderCompatibilityTest,
+     ChatCompletionHandlesMixedOrphanAndMatchedToolResults) {
+  const int port = quantclaw::test::FindFreePort();
+  ASSERT_GT(port, 0);
+
+  httplib::Server server;
+  std::vector<std::string> seen_tool_ids;
+  server.Post("/chat/completions", [&](const httplib::Request& req,
+                                       httplib::Response& res) {
+    const auto body = nlohmann::json::parse(req.body);
+    ASSERT_TRUE(body.contains("messages"));
+    for (const auto& message : body["messages"]) {
+      if (message.value("role", "") == "tool") {
+        seen_tool_ids.push_back(message.value("tool_call_id", ""));
+      }
+    }
+
+    nlohmann::json response = {
+        {"choices", nlohmann::json::array({{{"message", {{"content", "ok"}}},
+                                            {"finish_reason", "stop"}}})},
+    };
+    res.set_content(response.dump(), "application/json");
+  });
+
+  std::thread server_thread([&]() {
+    quantclaw::test::ReleaseHeldPort(port);
+    server.listen("127.0.0.1", port);
+  });
+  auto stop_server = [&]() {
+    server.stop();
+    if (server_thread.joinable()) {
+      server_thread.join();
+    }
+  };
+  if (!quantclaw::test::WaitForServerReady(port, 5000)) {
+    stop_server();
+    FAIL() << "Server not ready on port " << port;
+  }
+
+  auto null_sink = std::make_shared<spdlog::sinks::null_sink_mt>();
+  auto logger =
+      std::make_shared<spdlog::logger>("openai-mixed-tool", null_sink);
+  quantclaw::OpenAIProvider provider(
+      "test-key", "http://127.0.0.1:" + std::to_string(port), 30, logger);
+
+  quantclaw::ChatCompletionRequest request;
+  request.model = "qwen3-max";
+  request.messages.push_back({"user", "before"});
+
+  // Orphan tool_result (no preceding tool_calls)
+  quantclaw::Message orphan;
+  orphan.role = "user";
+  orphan.content.push_back(
+      quantclaw::ContentBlock::MakeToolResult("orphan-1", "stale data"));
+  request.messages.push_back(std::move(orphan));
+
+  // Valid assistant tool_use turn
+  quantclaw::Message assistant;
+  assistant.role = "assistant";
+  assistant.content.push_back(
+      quantclaw::ContentBlock::MakeToolUse("valid-1", "read", {{"path", "/y"}}));
+  request.messages.push_back(std::move(assistant));
+
+  // Matching tool_result for valid-1
+  quantclaw::Message matched_result;
+  matched_result.role = "user";
+  matched_result.content.push_back(
+      quantclaw::ContentBlock::MakeToolResult("valid-1", "real data"));
+  request.messages.push_back(std::move(matched_result));
+
+  // Another orphan tool_result (different id, no matching tool_use)
+  quantclaw::Message orphan2;
+  orphan2.role = "user";
+  orphan2.content.push_back(
+      quantclaw::ContentBlock::MakeToolResult("orphan-2", "old data"));
+  request.messages.push_back(std::move(orphan2));
+
+  request.messages.push_back({"user", "after"});
+
+  auto response = provider.ChatCompletion(request);
+  stop_server();
+
+  // Only "valid-1" should be sent; "orphan-1" and "orphan-2" should be skipped
+  ASSERT_EQ(seen_tool_ids.size(), 1u);
+  EXPECT_EQ(seen_tool_ids[0], "valid-1");
+  EXPECT_EQ(response.content, "ok");
+}
+
+TEST(OpenAIProviderCompatibilityTest,
+     ChatCompletionHandlesTruncatedSessionHistory) {
+  // Simulates auto-compaction: the assistant tool_use message is removed,
+  // but the tool_result message survives, creating an orphan.
+  const int port = quantclaw::test::FindFreePort();
+  ASSERT_GT(port, 0);
+
+  httplib::Server server;
+  std::vector<std::string> seen_tool_ids;
+  server.Post("/chat/completions", [&](const httplib::Request& req,
+                                       httplib::Response& res) {
+    const auto body = nlohmann::json::parse(req.body);
+    ASSERT_TRUE(body.contains("messages"));
+    for (const auto& message : body["messages"]) {
+      if (message.value("role", "") == "tool") {
+        seen_tool_ids.push_back(message.value("tool_call_id", ""));
+      }
+    }
+
+    nlohmann::json response = {
+        {"choices", nlohmann::json::array({{{"message", {{"content", "ok"}}},
+                                            {"finish_reason", "stop"}}})},
+    };
+    res.set_content(response.dump(), "application/json");
+  });
+
+  std::thread server_thread([&]() {
+    quantclaw::test::ReleaseHeldPort(port);
+    server.listen("127.0.0.1", port);
+  });
+  auto stop_server = [&]() {
+    server.stop();
+    if (server_thread.joinable()) {
+      server_thread.join();
+    }
+  };
+  if (!quantclaw::test::WaitForServerReady(port, 5000)) {
+    stop_server();
+    FAIL() << "Server not ready on port " << port;
+  }
+
+  auto null_sink = std::make_shared<spdlog::sinks::null_sink_mt>();
+  auto logger =
+      std::make_shared<spdlog::logger>("openai-truncated-session", null_sink);
+  quantclaw::OpenAIProvider provider(
+      "test-key", "http://127.0.0.1:" + std::to_string(port), 30, logger);
+
+  quantclaw::ChatCompletionRequest request;
+  request.model = "qwen3-max";
+
+  // === Simulated truncated session ===
+  // Original session had:
+  //   1. user: "read file"
+  //   2. assistant: tool_use(call-1, read, /tmp/a.txt)
+  //   3. user: tool_result(call-1, "file content here")
+  //   4. user: "read another file"
+  //   5. assistant: tool_use(call-2, read, /tmp/b.txt)
+  //   6. user: tool_result(call-2, "another file content")
+  //   7. user: "summarize"
+  //
+  // After compaction (keep_recent=4), messages 1-3 are dropped, leaving:
+  //   (compaction notice)
+  //   4. user: "read another file"
+  //   5. assistant: tool_use(call-2, read, /tmp/b.txt)
+  //   6. user: tool_result(call-2, "another file content")
+  //   7. user: "summarize"
+  //
+  // But if compaction drops 1-2 only (odd cutoff), we get:
+  //   (compaction notice)
+  //   3. user: tool_result(call-1, "file content here")  <-- ORPHAN
+  //   4. user: "read another file"
+  //   5. assistant: tool_use(call-2, read, /tmp/b.txt)
+  //   6. user: tool_result(call-2, "another file content")
+  //   7. user: "summarize"
+
+  request.messages.push_back(
+      {"system", "[Context compaction: 2 earlier messages were removed.]"});
+
+  // Orphan tool_result from before compaction
+  quantclaw::Message orphan;
+  orphan.role = "user";
+  orphan.content.push_back(
+      quantclaw::ContentBlock::MakeToolResult("call-1", "file content here"));
+  request.messages.push_back(std::move(orphan));
+
+  request.messages.push_back({"user", "read another file"});
+
+  // Valid assistant tool_use
+  quantclaw::Message assistant;
+  assistant.role = "assistant";
+  assistant.content.push_back(quantclaw::ContentBlock::MakeToolUse(
+      "call-2", "read", {{"path", "/tmp/b.txt"}}));
+  request.messages.push_back(std::move(assistant));
+
+  // Valid matching tool_result
+  quantclaw::Message valid_result;
+  valid_result.role = "user";
+  valid_result.content.push_back(quantclaw::ContentBlock::MakeToolResult(
+      "call-2", "another file content"));
+  request.messages.push_back(std::move(valid_result));
+
+  request.messages.push_back({"user", "summarize"});
+
+  auto response = provider.ChatCompletion(request);
+  stop_server();
+
+  // Only "call-2" should survive; "call-1" is an orphan and must be skipped
+  ASSERT_EQ(seen_tool_ids.size(), 1u);
+  EXPECT_EQ(seen_tool_ids[0], "call-2");
+  EXPECT_EQ(response.content, "ok");
+}
+
+TEST(OpenAIProviderCompatibilityTest,
      ChatCompletionRepairsCompatibleToolCallNameAndArguments) {
   const int port = quantclaw::test::FindFreePort();
   ASSERT_GT(port, 0);

--- a/tests/test_openai_provider.cpp
+++ b/tests/test_openai_provider.cpp
@@ -515,8 +515,8 @@ TEST(OpenAIProviderCompatibilityTest,
   // Valid assistant tool_use turn
   quantclaw::Message assistant;
   assistant.role = "assistant";
-  assistant.content.push_back(
-      quantclaw::ContentBlock::MakeToolUse("valid-1", "read", {{"path", "/y"}}));
+  assistant.content.push_back(quantclaw::ContentBlock::MakeToolUse(
+      "valid-1", "read", {{"path", "/y"}}));
   request.messages.push_back(std::move(assistant));
 
   // Matching tool_result for valid-1


### PR DESCRIPTION
## Summary
- align `OpenAICodexProvider` history replay with the orphan `tool_result` filtering already added to `OpenAIProvider`
- skip unmatched `function_call_output` items instead of replaying invalid stale tool results
- add a regression test covering matched and orphan tool results in the codex provider path

## Why
PR #137 fixed the stale tool-result history issue for `OpenAIProvider`, but `OpenAICodexProvider` still replayed orphan `tool_result` blocks as `function_call_output`, which can trigger 400 `bad_request` responses when truncated session history is replayed.

## Verification
- `cmake --build D:\test\github\QuantClaw\build-win --target quantclaw_tests`
- `D:\test\github\QuantClaw\build-win\quantclaw_tests.exe --gtest_filter=OpenAICodexProviderTest.*:OpenAIProviderCompatibilityTest.ChatCompletionSkipsOrphanToolResults`
- `D:\test\github\review\137\codex_repro\build\codex_repro.exe`